### PR TITLE
[codex] fix mobile player layout and release ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
-  pull_request:
 
 jobs:
   backend:
@@ -76,11 +74,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/backend
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=short
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - uses: docker/build-push-action@v6
         with:
@@ -115,11 +111,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/frontend
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,format=short
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - uses: docker/build-push-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ backend/music/
 
 # Local-only files that never belong in the repo
 _local/
+.DS_Store
 
 # Local agent/tooling state
 .pi/

--- a/mobile/app/now-playing.tsx
+++ b/mobile/app/now-playing.tsx
@@ -80,8 +80,10 @@ const PROGRESS_DISPLAY_INTERVAL_MS = 250;
 const TABLET_BREAKPOINT = 600;
 const TABLET_CONTENT_MAX_WIDTH = 760;
 const PHONE_BOTTOM_CONTROLS_ESTIMATE = 316;
-const PHONE_HERO_CONTROLS_GAP = 64;
 const HERO_META_BLOCK_HEIGHT = 54;
+const PHONE_ARTWORK_META_MIN_GAP = 44;
+const PHONE_META_CONTROLS_GAP = 14;
+const TABLET_ARTWORK_META_GAP = 82;
 
 type DisplayedQueue = {
   queue: TrackListItem[];
@@ -145,7 +147,6 @@ export default function NowPlayingScreen() {
   const coverStartTop = isTabletLayout
     ? Math.max(72, Math.round(availableBodyHeight * 0.11))
     : 60;
-  const metaGap = isTabletLayout ? 82 : 110;
   const preferredCoverSize = isTabletLayout
     ? Math.min(
         Math.round(bodyWidth * 0.74),
@@ -158,9 +159,9 @@ export default function NowPlayingScreen() {
     Math.round(
       bottomControlsTop -
         coverStartTop -
-        metaGap -
+        PHONE_ARTWORK_META_MIN_GAP -
         HERO_META_BLOCK_HEIGHT -
-        PHONE_HERO_CONTROLS_GAP,
+        PHONE_META_CONTROLS_GAP,
     ),
   );
   const coverSize = isTabletLayout
@@ -173,7 +174,12 @@ export default function NowPlayingScreen() {
   const coverStartCenterY = coverStartTop + coverSize / 2;
   const coverEndCenterX = coverEndLeft + COMPACT_COVER_SIZE / 2;
   const coverEndCenterY = coverEndTop + COMPACT_COVER_SIZE / 2;
-  const metaStartTop = coverStartTop + coverSize + metaGap;
+  const metaStartTop = isTabletLayout
+    ? coverStartTop + coverSize + TABLET_ARTWORK_META_GAP
+    : Math.max(
+        coverStartTop + coverSize + PHONE_ARTWORK_META_MIN_GAP,
+        bottomControlsTop - HERO_META_BLOCK_HEIGHT - PHONE_META_CONTROLS_GAP,
+      );
   const metaEndTop = 6;
   const metaStartLeft = 0;
   const metaEndLeft = COMPACT_COVER_SIZE + 6;

--- a/mobile/app/now-playing.tsx
+++ b/mobile/app/now-playing.tsx
@@ -79,6 +79,9 @@ const VOLUME_UPDATE_INTERVAL_MS = 80;
 const PROGRESS_DISPLAY_INTERVAL_MS = 250;
 const TABLET_BREAKPOINT = 600;
 const TABLET_CONTENT_MAX_WIDTH = 760;
+const PHONE_BOTTOM_CONTROLS_ESTIMATE = 316;
+const PHONE_HERO_CONTROLS_GAP = 64;
+const HERO_META_BLOCK_HEIGHT = 54;
 
 type DisplayedQueue = {
   queue: TrackListItem[];
@@ -121,13 +124,13 @@ export default function NowPlayingScreen() {
     });
   }, [queueOpen, transition]);
 
-  const coverSize = isTabletLayout
-    ? Math.min(
-        Math.round(bodyWidth * 0.74),
-        Math.round(availableBodyHeight * 0.46),
-        560,
-      )
-    : Math.min(Math.round(width * 0.62), 320);
+  const measuredBottomControls =
+    bottomControlsHeight ||
+    (isTabletLayout ? 244 : PHONE_BOTTOM_CONTROLS_ESTIMATE);
+  const bottomControlsTop = Math.max(
+    0,
+    availableBodyHeight - measuredBottomControls,
+  );
   const trackId = track?.id ?? null;
   const favorite = useFavorite(trackId ?? "");
   const previousTrackIdRef = useRef<string | null>(null);
@@ -142,6 +145,27 @@ export default function NowPlayingScreen() {
   const coverStartTop = isTabletLayout
     ? Math.max(72, Math.round(availableBodyHeight * 0.11))
     : 60;
+  const metaGap = isTabletLayout ? 82 : 110;
+  const preferredCoverSize = isTabletLayout
+    ? Math.min(
+        Math.round(bodyWidth * 0.74),
+        Math.round(availableBodyHeight * 0.46),
+        560,
+      )
+    : Math.min(Math.round(width * 0.62), 320);
+  const heightLimitedPhoneCoverSize = Math.max(
+    COMPACT_COVER_SIZE,
+    Math.round(
+      bottomControlsTop -
+        coverStartTop -
+        metaGap -
+        HERO_META_BLOCK_HEIGHT -
+        PHONE_HERO_CONTROLS_GAP,
+    ),
+  );
+  const coverSize = isTabletLayout
+    ? preferredCoverSize
+    : Math.min(preferredCoverSize, heightLimitedPhoneCoverSize);
   const coverStartLeft = Math.max(0, (bodyWidth - coverSize) / 2);
   const coverEndTop = 2;
   const coverEndLeft = 0;
@@ -149,8 +173,7 @@ export default function NowPlayingScreen() {
   const coverStartCenterY = coverStartTop + coverSize / 2;
   const coverEndCenterX = coverEndLeft + COMPACT_COVER_SIZE / 2;
   const coverEndCenterY = coverEndTop + COMPACT_COVER_SIZE / 2;
-  const metaStartTop =
-    coverStartTop + coverSize + (isTabletLayout ? 82 : 110);
+  const metaStartTop = coverStartTop + coverSize + metaGap;
   const metaEndTop = 6;
   const metaStartLeft = 0;
   const metaEndLeft = COMPACT_COVER_SIZE + 6;
@@ -159,7 +182,6 @@ export default function NowPlayingScreen() {
   const metaEndWidth = Math.max(120, actionsLeft - metaEndLeft - 10);
   const heroExpandedHeight = metaStartTop + 50;
   const heroCompactHeight = COMPACT_COVER_SIZE + 2;
-  const measuredBottomControls = bottomControlsHeight || 244;
   const queueBottomInset = measuredBottomControls + 18;
   const queueOpenTop = heroCompactHeight + 4;
   const queueClosedTop = Math.max(


### PR DESCRIPTION
## What changed

- Added a height-aware phone layout budget to the mobile now-playing screen so the metadata/action row cannot collide with the progress scrubber on constrained mobile heights.
- Changed CI to run only for version tag pushes matching `v*`.
- Removed branch/latest Docker metadata tags because the workflow no longer runs for branch pushes.

## Why

The now-playing screen sized phone artwork from width while anchoring controls from the bottom. On some mobile viewports, the bottom controls could rise into the title and action row. CI was also requested to run only for version pushes.

## Validation

- `npx tsc --noEmit` in `mobile`
- `git diff --check -- .github/workflows/ci.yml mobile/app/now-playing.tsx`

Note: `npm run lint` still reports existing `import/no-unresolved` failures for `@music-library/core` across the mobile app, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved now-playing screen layout and spacing calculations for better mobile device compatibility.

* **Chores**
  * Updated CI workflow image tagging configuration.
  * Added macOS system files to development ignore list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->