### PR TITLE
[codex] Add API tracker tabs and era covers

### DIFF
--- a/backend/docs/api-tracker.md
+++ b/backend/docs/api-tracker.md
@@ -18,13 +18,13 @@ of it — the upstream sees the full `/api/...` path.
 
 | How you reach it | URL |
 | --- | --- |
-| **Production** | `https://trackers.misleadi.ng/api` |
+| **Production** | `https://trackers.musicfiles.su/api` |
 | Through the bundled Nginx (`backend/nginx/tracker.conf`, listens on `:80`) | `http://your-host/api` |
 | Directly against the Go service in Docker Compose | `http://127.0.0.1:4444/api` |
 
-The production deployment is served at `trackers.misleadi.ng`; call the API at
-`https://trackers.misleadi.ng/api/...` (e.g.
-`https://trackers.misleadi.ng/api/v1/trackers`).
+The production deployment is served at `trackers.musicfiles.su`; call the API at
+`https://trackers.musicfiles.su/api/...` (e.g.
+`https://trackers.musicfiles.su/api/v1/trackers`).
 
 The Go process binds `:$PORT`. The code default for `PORT` is `8080`; the
 provided `docker-compose.yml` sets `PORT=4444` and publishes it on

--- a/backend/internal/apitracker/client.go
+++ b/backend/internal/apitracker/client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/githubesson/lumen/internal/lastshare"
 )
 
-const DefaultBaseURL = "https://trackers.misleadi.ng/api"
+const DefaultBaseURL = "https://trackers.musicfiles.su/api"
 
 type Client struct {
 	HTTP    *http.Client
@@ -40,6 +40,13 @@ type Tracker struct {
 	SpreadsheetID  string   `json:"spreadsheet_id"`
 	GID            string   `json:"gid"`
 	EntryCount     int64    `json:"entry_count"`
+}
+
+type Era struct {
+	Era      string `json:"era"`
+	EraKey   string `json:"era_key"`
+	ImageID  int64  `json:"image_id"`
+	ImageURL string `json:"image_url"`
 }
 
 type Entry struct {
@@ -72,6 +79,11 @@ type entriesPage struct {
 	Limit  int     `json:"limit"`
 	Offset int     `json:"offset"`
 	Total  int     `json:"total"`
+}
+
+type erasPage struct {
+	Items []Era `json:"items"`
+	Total int   `json:"total"`
 }
 
 func NewClient(baseURL string) *Client {
@@ -126,6 +138,64 @@ func (c *Client) FetchEntries(ctx context.Context, trackerID int64) ([]Entry, er
 		}
 	}
 	return out, nil
+}
+
+func (c *Client) FetchEras(ctx context.Context, trackerID int64) ([]Era, error) {
+	if trackerID <= 0 {
+		return nil, fmt.Errorf("tracker id must be positive")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiURL("/v1/trackers/"+strconv.FormatInt(trackerID, 10)+"/eras"), nil)
+	if err != nil {
+		return nil, err
+	}
+	setHeaders(req)
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("api tracker eras %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var page erasPage
+	if err := decodeJSON(resp.Body, &page); err != nil {
+		return nil, err
+	}
+	return page.Items, nil
+}
+
+func (c *Client) FetchEraImage(ctx context.Context, imageID int64) ([]byte, string, error) {
+	if imageID <= 0 {
+		return nil, "", fmt.Errorf("image id must be positive")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiURL("/v1/era-images/"+strconv.FormatInt(imageID, 10)), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Accept", "image/*")
+	req.Header.Set("User-Agent", httpx.BrowserUserAgent)
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("api tracker era image %s", resp.Status)
+	}
+	contentType := strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])
+	if !strings.HasPrefix(strings.ToLower(contentType), "image/") {
+		return nil, "", fmt.Errorf("api tracker era image returned %q", contentType)
+	}
+	const maxEraImageBytes = 20 << 20
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxEraImageBytes+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) > maxEraImageBytes {
+		return nil, "", fmt.Errorf("api tracker era image exceeds 20MiB")
+	}
+	return data, contentType, nil
 }
 
 func (c *Client) fetchEntriesPage(ctx context.Context, trackerID int64, limit, offset int) (entriesPage, error) {

--- a/backend/internal/apitracker/client_test.go
+++ b/backend/internal/apitracker/client_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestExtractTrackerIDAndBaseURL(t *testing.T) {
-	raw := "https://trackers.misleadi.ng/api/v1/trackers/42/entries?limit=50"
+	raw := "https://trackers.musicfiles.su/api/v1/trackers/42/entries?limit=50"
 	if got := ExtractTrackerID(raw); got != 42 {
 		t.Fatalf("tracker id = %d, want 42", got)
 	}
-	if got := ExtractBaseURL(raw); got != "https://trackers.misleadi.ng/api" {
+	if got := ExtractBaseURL(raw); got != "https://trackers.musicfiles.su/api" {
 		t.Fatalf("base url = %q", got)
 	}
-	if got := NormalizeBaseURL(raw); got != "https://trackers.misleadi.ng/api" {
+	if got := NormalizeBaseURL(raw); got != "https://trackers.musicfiles.su/api" {
 		t.Fatalf("normalized base url = %q", got)
 	}
 }
@@ -59,5 +59,45 @@ func TestFetchEntriesPagesUntilComplete(t *testing.T) {
 	}
 	if len(offsets) != 2 || offsets[0] != "0" || offsets[1] != "500" {
 		t.Fatalf("offsets = %#v, want [0 500]", offsets)
+	}
+}
+
+func TestFetchErasAndEraImage(t *testing.T) {
+	imageBytes := []byte{0x89, 'P', 'N', 'G'}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/trackers/7/eras":
+			_ = json.NewEncoder(w).Encode(erasPage{
+				Items: []Era{{
+					Era:      "Working On Dying",
+					EraKey:   "working on dying",
+					ImageID:  12,
+					ImageURL: "/api/v1/era-images/12",
+				}},
+				Total: 1,
+			})
+		case "/api/v1/era-images/12":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(imageBytes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL + "/api")
+	eras, err := client.FetchEras(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(eras) != 1 || eras[0].ImageID != 12 || eras[0].EraKey != "working on dying" {
+		t.Fatalf("unexpected eras: %#v", eras)
+	}
+	data, contentType, err := client.FetchEraImage(context.Background(), 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "image/png" || string(data) != string(imageBytes) {
+		t.Fatalf("unexpected image response type=%q data=%#v", contentType, data)
 	}
 }

--- a/backend/internal/apitracker/scanner.go
+++ b/backend/internal/apitracker/scanner.go
@@ -175,16 +175,22 @@ func (s *Scanner) scanPin(ctx context.Context, pin Pin, summary *ScanSummary) er
 			s.Logger.Warn("api tracker metadata update failed", "pin", pin.ID, "err", err)
 		}
 	}
+	eraImages := s.fetchEraImageIDs(ctx, client, pin.TrackerID)
+	eraCoverKeys := map[int64]string{}
 	entries, err := client.FetchEntries(ctx, pin.TrackerID)
 	if err != nil {
 		return err
 	}
 	for _, entry := range entries {
+		if !pinMatchesEntryTab(pin, entry) {
+			continue
+		}
 		if len(entry.Links) == 0 {
 			summary.NoURL++
 			continue
 		}
 		trackCtx := BuildContext(tracker, pin, entry)
+		coverKey := s.eraCoverKey(ctx, client, eraImages, eraCoverKeys, trackCtx.Album)
 		sourceURLs := s.expandRecordURLs(ctx, client, entry.Links)
 		for i, sourceURL := range sourceURLs {
 			sourceURL = strings.TrimSpace(sourceURL)
@@ -213,7 +219,7 @@ func (s *Scanner) scanPin(ctx context.Context, pin Pin, summary *ScanSummary) er
 				})
 				continue
 			}
-			if s.previousStillPresent(ctx, pin.ID, sourceURL, summary) {
+			if s.previousStillPresent(ctx, pin.ID, sourceURL, coverKey, summary) {
 				continue
 			}
 			status, resolvedURL, filePath, trackID, ingestInserted, err := s.downloadOne(
@@ -261,6 +267,7 @@ func (s *Scanner) scanPin(ctx context.Context, pin Pin, summary *ScanSummary) er
 			if ingestInserted {
 				summary.Ingested++
 			}
+			s.applyTrackAlbumCover(ctx, trackID, coverKey)
 			_ = s.Store.RecordDownload(ctx, DownloadInput{
 				PinID:       pin.ID,
 				EntryID:     entry.ID,
@@ -277,6 +284,7 @@ func (s *Scanner) scanPin(ctx context.Context, pin Pin, summary *ScanSummary) er
 		s.Logger.Info("api tracker scan complete",
 			"pin", pin.ID,
 			"tracker", pin.TrackerID,
+			"tab", pin.Tab,
 			"seen", summary.Seen,
 			"downloaded", summary.Downloaded,
 			"existing", summary.Existing,
@@ -284,6 +292,72 @@ func (s *Scanner) scanPin(ctx context.Context, pin Pin, summary *ScanSummary) er
 			"failed", summary.Failed)
 	}
 	return nil
+}
+
+func pinMatchesEntryTab(pin Pin, entry Entry) bool {
+	tab := strings.TrimSpace(pin.Tab)
+	if tab == "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(entry.SheetName), tab)
+}
+
+func (s *Scanner) fetchEraImageIDs(ctx context.Context, client *Client, trackerID int64) map[string]int64 {
+	eras, err := client.FetchEras(ctx, trackerID)
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("api tracker eras fetch failed", "tracker", trackerID, "err", err)
+		}
+		return nil
+	}
+	out := make(map[string]int64, len(eras)*2)
+	for _, era := range eras {
+		if era.ImageID <= 0 {
+			continue
+		}
+		for _, key := range []string{era.EraKey, era.Era} {
+			key = normalizeEraKey(key)
+			if key != "" {
+				out[key] = era.ImageID
+			}
+		}
+	}
+	return out
+}
+
+func (s *Scanner) eraCoverKey(ctx context.Context, client *Client, eraImages map[string]int64, cache map[int64]string, era string) string {
+	if s == nil || s.Ingest == nil || len(eraImages) == 0 {
+		return ""
+	}
+	imageID := eraImages[normalizeEraKey(era)]
+	if imageID <= 0 {
+		return ""
+	}
+	if key, ok := cache[imageID]; ok {
+		return key
+	}
+	data, contentType, err := client.FetchEraImage(ctx, imageID)
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("api tracker era image fetch failed", "image_id", imageID, "era", era, "err", err)
+		}
+		cache[imageID] = ""
+		return ""
+	}
+	key, err := s.Ingest.StoreCoverImage(ctx, data, contentType)
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("api tracker era image store failed", "image_id", imageID, "era", era, "err", err)
+		}
+		cache[imageID] = ""
+		return ""
+	}
+	cache[imageID] = key
+	return key
+}
+
+func normalizeEraKey(raw string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(raw))), " ")
 }
 
 func (s *Scanner) clientFor(pin Pin) *Client {
@@ -318,7 +392,7 @@ func (s *Scanner) expandRecordURLs(ctx context.Context, client *Client, urls []s
 	return out
 }
 
-func (s *Scanner) previousStillPresent(ctx context.Context, pinID uuid.UUID, sourceURL string, summary *ScanSummary) bool {
+func (s *Scanner) previousStillPresent(ctx context.Context, pinID uuid.UUID, sourceURL string, coverKey string, summary *ScanSummary) bool {
 	prev, err := s.Store.DownloadForSource(ctx, pinID, sourceURL)
 	if err != nil {
 		return false
@@ -333,6 +407,7 @@ func (s *Scanner) previousStillPresent(ctx context.Context, pinID uuid.UUID, sou
 		if prev.FilePath != "" && fileNonEmpty(prev.FilePath) {
 			if prev.TrackID == nil {
 				trackID, inserted := s.ingestPath(ctx, prev.FilePath, TrackContext{}, false)
+				s.applyTrackAlbumCover(ctx, trackID, coverKey)
 				_ = s.Store.RecordDownload(ctx, DownloadInput{
 					PinID:       pinID,
 					EntryID:     prev.EntryID,
@@ -346,6 +421,8 @@ func (s *Scanner) previousStillPresent(ctx context.Context, pinID uuid.UUID, sou
 				if inserted {
 					summary.Ingested++
 				}
+			} else {
+				s.applyTrackAlbumCover(ctx, prev.TrackID, coverKey)
 			}
 			summary.Existing++
 			return true
@@ -504,6 +581,15 @@ func (s *Scanner) applyTrackerMetadata(ctx context.Context, trackID uuid.UUID, t
 	}
 }
 
+func (s *Scanner) applyTrackAlbumCover(ctx context.Context, trackID *uuid.UUID, coverKey string) {
+	if s == nil || s.Library == nil || trackID == nil || *trackID == uuid.Nil || coverKey == "" {
+		return
+	}
+	if err := s.Library.SetTrackAlbumCover(ctx, *trackID, coverKey); err != nil && s.Logger != nil {
+		s.Logger.Warn("api tracker album cover apply failed", "track", *trackID, "cover_key", coverKey, "err", err)
+	}
+}
+
 func pinDestination(pin Pin) (string, error) {
 	root, err := filepath.Abs(pin.RootPath)
 	if err != nil {
@@ -563,6 +649,7 @@ func entryMetadata(tracker Tracker, pin Pin, entry Entry, tc TrackContext) json.
 		"tracker_id":     pin.TrackerID,
 		"tracker":        firstNonEmpty(tracker.TrackerName, pin.TrackerName),
 		"tracker_url":    firstNonEmpty(tracker.URL, pin.TrackerURL),
+		"tab":            pin.Tab,
 		"entry_id":       entry.ID,
 		"sheet_id":       entry.SheetID,
 		"sheet":          entry.SheetName,

--- a/backend/internal/apitracker/scanner_test.go
+++ b/backend/internal/apitracker/scanner_test.go
@@ -61,6 +61,24 @@ func TestDownloadOneSkipsUnsupportedExtensionBeforeWriting(t *testing.T) {
 	}
 }
 
+func TestPinMatchesEntryTab(t *testing.T) {
+	if !pinMatchesEntryTab(Pin{}, Entry{SheetName: "Leaks"}) {
+		t.Fatal("blank pin tab should match every entry")
+	}
+	if !pinMatchesEntryTab(Pin{Tab: "leaks"}, Entry{SheetName: "Leaks"}) {
+		t.Fatal("tab match should be case-insensitive")
+	}
+	if pinMatchesEntryTab(Pin{Tab: "Demos"}, Entry{SheetName: "Leaks"}) {
+		t.Fatal("different tab should not match")
+	}
+}
+
+func TestNormalizeEraKey(t *testing.T) {
+	if got := normalizeEraKey("  Working   On Dying  "); got != "working on dying" {
+		t.Fatalf("normalizeEraKey = %q", got)
+	}
+}
+
 func TestDownloadOneRejectsLoopbackByDefaultBeforeRequest(t *testing.T) {
 	var requested bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/apitracker/store.go
+++ b/backend/internal/apitracker/store.go
@@ -38,6 +38,7 @@ type Pin struct {
 	TrackerID           int64      `json:"tracker_id"`
 	TrackerName         string     `json:"tracker_name"`
 	TrackerURL          string     `json:"tracker_url"`
+	Tab                 string     `json:"tab"`
 	Label               string     `json:"label"`
 	PrimaryArtist       string     `json:"primary_artist"`
 	Enabled             bool       `json:"enabled"`
@@ -57,6 +58,7 @@ type AddPinInput struct {
 	TrackerID           int64
 	TrackerName         string
 	TrackerURL          string
+	Tab                 string
 	Label               string
 	PrimaryArtist       string
 	Enabled             bool
@@ -65,6 +67,7 @@ type AddPinInput struct {
 
 type PatchPinInput struct {
 	DestinationSubdir   *string
+	Tab                 *string
 	Label               *string
 	PrimaryArtist       *string
 	Enabled             *bool
@@ -108,7 +111,7 @@ func NewStore(db *pgxpool.Pool) *Store { return &Store{db: db} }
 func (s *Store) ListPins(ctx context.Context) ([]Pin, error) {
 	rows, err := s.db.Query(ctx, `
 		SELECT id, root_id, root_path, destination_subdir, api_base_url,
-		       tracker_id, tracker_name, tracker_url, label, primary_artist,
+		       tracker_id, tracker_name, tracker_url, tab, label, primary_artist,
 		       enabled, scan_interval_seconds, last_scan_at, last_success_at,
 		       last_error, created_at, updated_at
 		FROM api_tracker_pins
@@ -134,7 +137,7 @@ func (s *Store) DuePins(ctx context.Context, limit int) ([]Pin, error) {
 	}
 	rows, err := s.db.Query(ctx, `
 		SELECT id, root_id, root_path, destination_subdir, api_base_url,
-		       tracker_id, tracker_name, tracker_url, label, primary_artist,
+		       tracker_id, tracker_name, tracker_url, tab, label, primary_artist,
 		       enabled, scan_interval_seconds, last_scan_at, last_success_at,
 		       last_error, created_at, updated_at
 		FROM api_tracker_pins
@@ -163,7 +166,7 @@ func (s *Store) DuePins(ctx context.Context, limit int) ([]Pin, error) {
 func (s *Store) GetPin(ctx context.Context, id uuid.UUID) (Pin, error) {
 	p, err := scanPin(s.db.QueryRow(ctx, `
 		SELECT id, root_id, root_path, destination_subdir, api_base_url,
-		       tracker_id, tracker_name, tracker_url, label, primary_artist,
+		       tracker_id, tracker_name, tracker_url, tab, label, primary_artist,
 		       enabled, scan_interval_seconds, last_scan_at, last_success_at,
 		       last_error, created_at, updated_at
 		FROM api_tracker_pins
@@ -188,15 +191,15 @@ func (s *Store) AddPin(ctx context.Context, in AddPinInput) (Pin, error) {
 	p, err := scanPin(s.db.QueryRow(ctx, `
 		INSERT INTO api_tracker_pins (
 			root_id, root_path, destination_subdir, api_base_url, tracker_id,
-			tracker_name, tracker_url, label, primary_artist, enabled, scan_interval_seconds
+			tracker_name, tracker_url, tab, label, primary_artist, enabled, scan_interval_seconds
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		RETURNING id, root_id, root_path, destination_subdir, api_base_url,
-		          tracker_id, tracker_name, tracker_url, label, primary_artist,
+		          tracker_id, tracker_name, tracker_url, tab, label, primary_artist,
 		          enabled, scan_interval_seconds, last_scan_at, last_success_at,
 		          last_error, created_at, updated_at`,
 		dbutil.NullableUUID(in.RootID), in.RootPath, in.DestinationSubdir, in.APIBaseURL,
-		in.TrackerID, in.TrackerName, in.TrackerURL, in.Label, in.PrimaryArtist, in.Enabled,
+		in.TrackerID, in.TrackerName, in.TrackerURL, in.Tab, in.Label, in.PrimaryArtist, in.Enabled,
 		in.ScanIntervalSeconds,
 	))
 	if err != nil && dbutil.IsUniqueViolation(err) {
@@ -210,6 +213,9 @@ func (s *Store) PatchPin(ctx context.Context, id uuid.UUID, in PatchPinInput) (P
 	set.AddRaw("updated_at = NOW()")
 	if in.DestinationSubdir != nil {
 		set.Add("destination_subdir = $%d", *in.DestinationSubdir)
+	}
+	if in.Tab != nil {
+		set.Add("tab = $%d", *in.Tab)
 	}
 	if in.Label != nil {
 		set.Add("label = $%d", *in.Label)
@@ -232,7 +238,7 @@ func (s *Store) PatchPin(ctx context.Context, id uuid.UUID, in PatchPinInput) (P
 		UPDATE api_tracker_pins SET %s
 		WHERE id = $%d
 		RETURNING id, root_id, root_path, destination_subdir, api_base_url,
-		          tracker_id, tracker_name, tracker_url, label, primary_artist,
+		          tracker_id, tracker_name, tracker_url, tab, label, primary_artist,
 		          enabled, scan_interval_seconds, last_scan_at, last_success_at,
 		          last_error, created_at, updated_at`,
 		setClause, len(args),
@@ -379,7 +385,7 @@ func scanPin(row scanner) (Pin, error) {
 	)
 	err := row.Scan(
 		&p.ID, &rootID, &p.RootPath, &p.DestinationSubdir, &p.APIBaseURL,
-		&p.TrackerID, &p.TrackerName, &p.TrackerURL, &p.Label, &p.PrimaryArtist,
+		&p.TrackerID, &p.TrackerName, &p.TrackerURL, &p.Tab, &p.Label, &p.PrimaryArtist,
 		&p.Enabled, &p.ScanIntervalSeconds, &lastScan, &lastSuccess,
 		&p.LastError, &p.CreatedAt, &p.UpdatedAt,
 	)

--- a/backend/internal/db/migrations/0003_track_ownership.up.sql
+++ b/backend/internal/db/migrations/0003_track_ownership.up.sql
@@ -17,8 +17,8 @@ ALTER TABLE tracks DROP CONSTRAINT tracks_audio_sha256_key;
 
 CREATE UNIQUE INDEX tracks_global_sha_uniq
     ON tracks (audio_sha256)
-    WHERE owner_id IS NULL;
+    WHERE owner_id IS NULL AND deleted_at IS NULL;
 
 CREATE UNIQUE INDEX tracks_personal_sha_uniq
     ON tracks (owner_id, audio_sha256)
-    WHERE owner_id IS NOT NULL;
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;

--- a/backend/internal/db/migrations/0009_api_tracker_pins.up.sql
+++ b/backend/internal/db/migrations/0009_api_tracker_pins.up.sql
@@ -3,10 +3,11 @@ CREATE TABLE api_tracker_pins (
     root_id               UUID REFERENCES music_roots(id) ON DELETE CASCADE,
     root_path             TEXT NOT NULL,
     destination_subdir    TEXT NOT NULL DEFAULT '',
-    api_base_url          TEXT NOT NULL DEFAULT 'https://trackers.misleadi.ng/api',
+    api_base_url          TEXT NOT NULL DEFAULT 'https://trackers.musicfiles.su/api',
     tracker_id            BIGINT NOT NULL CHECK (tracker_id > 0),
     tracker_name          TEXT NOT NULL DEFAULT '',
     tracker_url           TEXT NOT NULL DEFAULT '',
+    tab                   TEXT NOT NULL DEFAULT '',
     label                 TEXT NOT NULL DEFAULT '',
     primary_artist        TEXT NOT NULL DEFAULT '',
     enabled               BOOLEAN NOT NULL DEFAULT TRUE,
@@ -16,7 +17,8 @@ CREATE TABLE api_tracker_pins (
     last_error            TEXT NOT NULL DEFAULT '',
     created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    UNIQUE (root_path, destination_subdir, api_base_url, tracker_id)
+    CONSTRAINT api_tracker_pins_unique_source
+        UNIQUE (root_path, destination_subdir, api_base_url, tracker_id, tab)
 );
 CREATE INDEX api_tracker_pins_due_idx
     ON api_tracker_pins(enabled, last_scan_at);

--- a/backend/internal/db/migrations/0011_api_tracker_base_url.down.sql
+++ b/backend/internal/db/migrations/0011_api_tracker_base_url.down.sql
@@ -1,0 +1,6 @@
+UPDATE api_tracker_pins
+SET api_base_url = 'https://trackers.misleadi.ng/api'
+WHERE api_base_url = 'https://trackers.musicfiles.su/api';
+
+ALTER TABLE api_tracker_pins
+    ALTER COLUMN api_base_url SET DEFAULT 'https://trackers.misleadi.ng/api';

--- a/backend/internal/db/migrations/0011_api_tracker_base_url.up.sql
+++ b/backend/internal/db/migrations/0011_api_tracker_base_url.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE api_tracker_pins
+    ALTER COLUMN api_base_url SET DEFAULT 'https://trackers.musicfiles.su/api';
+
+UPDATE api_tracker_pins
+SET api_base_url = 'https://trackers.musicfiles.su/api'
+WHERE api_base_url = 'https://trackers.misleadi.ng/api';

--- a/backend/internal/db/migrations/0012_api_tracker_tab.down.sql
+++ b/backend/internal/db/migrations/0012_api_tracker_tab.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE api_tracker_pins
+    DROP CONSTRAINT IF EXISTS api_tracker_pins_unique_source;
+
+ALTER TABLE api_tracker_pins
+    ADD CONSTRAINT api_tracker_pins_root_path_destination_subdir_api_base_url_tracker_id_key
+    UNIQUE (root_path, destination_subdir, api_base_url, tracker_id);
+
+ALTER TABLE api_tracker_pins
+    DROP COLUMN IF EXISTS tab;

--- a/backend/internal/db/migrations/0012_api_tracker_tab.up.sql
+++ b/backend/internal/db/migrations/0012_api_tracker_tab.up.sql
@@ -1,0 +1,28 @@
+ALTER TABLE api_tracker_pins
+    ADD COLUMN IF NOT EXISTS tab TEXT NOT NULL DEFAULT '';
+
+DO $$
+DECLARE
+    old_constraint text;
+BEGIN
+    SELECT conname INTO old_constraint
+    FROM pg_constraint
+    WHERE conrelid = 'api_tracker_pins'::regclass
+      AND contype = 'u'
+      AND pg_get_constraintdef(oid) = 'UNIQUE (root_path, destination_subdir, api_base_url, tracker_id)';
+
+    IF old_constraint IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE api_tracker_pins DROP CONSTRAINT %I', old_constraint);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'api_tracker_pins'::regclass
+          AND conname = 'api_tracker_pins_unique_source'
+    ) THEN
+        ALTER TABLE api_tracker_pins
+            ADD CONSTRAINT api_tracker_pins_unique_source
+            UNIQUE (root_path, destination_subdir, api_base_url, tracker_id, tab);
+    END IF;
+END $$;

--- a/backend/internal/db/migrations/0013_track_sha_ignore_deleted.down.sql
+++ b/backend/internal/db/migrations/0013_track_sha_ignore_deleted.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS tracks_personal_sha_uniq;
+DROP INDEX IF EXISTS tracks_global_sha_uniq;
+
+CREATE UNIQUE INDEX tracks_global_sha_uniq
+    ON tracks (audio_sha256)
+    WHERE owner_id IS NULL;
+
+CREATE UNIQUE INDEX tracks_personal_sha_uniq
+    ON tracks (owner_id, audio_sha256)
+    WHERE owner_id IS NOT NULL;

--- a/backend/internal/db/migrations/0013_track_sha_ignore_deleted.up.sql
+++ b/backend/internal/db/migrations/0013_track_sha_ignore_deleted.up.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS tracks_global_sha_uniq;
+DROP INDEX IF EXISTS tracks_personal_sha_uniq;
+
+CREATE UNIQUE INDEX tracks_global_sha_uniq
+    ON tracks (audio_sha256)
+    WHERE owner_id IS NULL AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX tracks_personal_sha_uniq
+    ON tracks (owner_id, audio_sha256)
+    WHERE owner_id IS NOT NULL AND deleted_at IS NULL;

--- a/backend/internal/httpapi/handlers/admin_apitracker.go
+++ b/backend/internal/httpapi/handlers/admin_apitracker.go
@@ -32,6 +32,7 @@ type apiTrackerPinResp struct {
 	TrackerID           int64      `json:"tracker_id"`
 	TrackerName         string     `json:"tracker_name"`
 	TrackerURL          string     `json:"tracker_url"`
+	Tab                 string     `json:"tab"`
 	Label               string     `json:"label"`
 	PrimaryArtist       string     `json:"primary_artist"`
 	Enabled             bool       `json:"enabled"`
@@ -53,6 +54,7 @@ type addAPITrackerPinReq struct {
 	TrackerID           flexibleID64 `json:"tracker_id"`
 	TrackerURL          string       `json:"tracker_url"`
 	TrackerName         string       `json:"tracker_name"`
+	Tab                 string       `json:"tab"`
 	Label               string       `json:"label"`
 	PrimaryArtist       string       `json:"primary_artist"`
 	Enabled             *bool        `json:"enabled"`
@@ -61,6 +63,7 @@ type addAPITrackerPinReq struct {
 
 type patchAPITrackerPinReq struct {
 	DestinationSubdir   *string `json:"destination_subdir"`
+	Tab                 *string `json:"tab"`
 	Label               *string `json:"label"`
 	PrimaryArtist       *string `json:"primary_artist"`
 	Enabled             *bool   `json:"enabled"`
@@ -150,6 +153,7 @@ func (h *AdminAPITracker) Add(w http.ResponseWriter, r *http.Request) {
 		TrackerID:           trackerID,
 		TrackerName:         strings.TrimSpace(req.TrackerName),
 		TrackerURL:          trackerURL,
+		Tab:                 strings.TrimSpace(req.Tab),
 		Label:               strings.TrimSpace(req.Label),
 		PrimaryArtist:       strings.TrimSpace(req.PrimaryArtist),
 		Enabled:             enabled,
@@ -171,7 +175,7 @@ func (h *AdminAPITracker) Patch(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	if req.DestinationSubdir == nil && req.Label == nil &&
+	if req.DestinationSubdir == nil && req.Tab == nil && req.Label == nil &&
 		req.PrimaryArtist == nil && req.Enabled == nil && req.ScanIntervalSeconds == nil {
 		http.Error(w, "nothing to update", http.StatusBadRequest)
 		return
@@ -179,10 +183,12 @@ func (h *AdminAPITracker) Patch(w http.ResponseWriter, r *http.Request) {
 	if !resolvePatchSubdir(w, r, id, apitracker.ErrNotFound, h.pinRootPath, &req.DestinationSubdir) {
 		return
 	}
+	cleanStringPtr(req.Tab)
 	cleanStringPtr(req.Label)
 	cleanStringPtr(req.PrimaryArtist)
 	pin, err := h.Store.PatchPin(r.Context(), id, apitracker.PatchPinInput{
 		DestinationSubdir:   req.DestinationSubdir,
+		Tab:                 req.Tab,
 		Label:               req.Label,
 		PrimaryArtist:       req.PrimaryArtist,
 		Enabled:             req.Enabled,
@@ -232,6 +238,7 @@ func (h *AdminAPITracker) pinResp(pin apitracker.Pin) apiTrackerPinResp {
 		TrackerID:           pin.TrackerID,
 		TrackerName:         pin.TrackerName,
 		TrackerURL:          pin.TrackerURL,
+		Tab:                 pin.Tab,
 		Label:               pin.Label,
 		PrimaryArtist:       pin.PrimaryArtist,
 		Enabled:             pin.Enabled,

--- a/backend/internal/library/store.go
+++ b/backend/internal/library/store.go
@@ -264,6 +264,10 @@ func InsertTrack(ctx context.Context, q pgx.Tx, t TrackInsert) (id uuid.UUID, in
 	t.Comments = dbtext.Clean(t.Comments)
 	t.Format = dbtext.Clean(t.Format)
 
+	if _, err := q.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended(encode($1::bytea, 'hex'), 0))`, t.AudioSHA256); err != nil {
+		return uuid.Nil, false, err
+	}
+
 	// 1. Is there already a global row with this SHA?
 	var globalID uuid.UUID
 	err = q.QueryRow(ctx, `SELECT id FROM tracks WHERE audio_sha256 = $1 AND owner_id IS NULL AND deleted_at IS NULL`, t.AudioSHA256).Scan(&globalID)
@@ -629,6 +633,24 @@ func (s *Store) SetAlbumCover(ctx context.Context, albumID uuid.UUID, coverPath 
 		return ErrNotFound
 	}
 	return nil
+}
+
+// SetTrackAlbumCover points the track's album at coverPath. It is
+// intentionally opportunistic: tracks without albums simply result in no rows
+// updated.
+func (s *Store) SetTrackAlbumCover(ctx context.Context, trackID uuid.UUID, coverPath string) error {
+	coverPath = dbtext.Clean(coverPath)
+	if coverPath == "" {
+		return nil
+	}
+	_, err := s.db.Exec(ctx, `
+		UPDATE albums a
+		SET cover_art_path = $2, updated_at = NOW()
+		FROM tracks t
+		WHERE t.id = $1
+		  AND t.album_id = a.id`,
+		trackID, coverPath)
+	return err
 }
 
 // ClearAlbumCover removes an album's cover-art reference, reverting it to the

--- a/core/src/api.ts
+++ b/core/src/api.ts
@@ -234,6 +234,10 @@ function filenPinPathID(id: string): string {
   return pinPathID(id, "Filen");
 }
 
+function apiTrackerPinPathID(id: string): string {
+  return pinPathID(id, "API tracker");
+}
+
 export const api = {
   login: (username: string, password: string) =>
     request<Me>("/api/auth/login", {
@@ -354,6 +358,37 @@ export const api = {
     const safeLimit = Math.max(1, Math.min(500, Math.trunc(limit) || 50));
     return request<FilenDownload[]>(
       `/api/admin/library/filen/pins/${filenPinPathID(id)}/downloads?limit=${safeLimit}`,
+    );
+  },
+  listAPITrackerPins: () =>
+    request<APITrackerPin[]>("/api/admin/library/api-trackers/pins"),
+  createAPITrackerPin: (input: APITrackerPinCreate) =>
+    request<APITrackerPin>("/api/admin/library/api-trackers/pins", {
+      method: "POST",
+      body: JSON.stringify(input),
+    }),
+  updateAPITrackerPin: (id: string, input: APITrackerPinPatch) =>
+    request<APITrackerPin>(
+      `/api/admin/library/api-trackers/pins/${apiTrackerPinPathID(id)}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      },
+    ),
+  deleteAPITrackerPin: (id: string) =>
+    requestVoid(
+      `/api/admin/library/api-trackers/pins/${apiTrackerPinPathID(id)}`,
+      { method: "DELETE" },
+    ),
+  scanAPITrackerPin: (id: string) =>
+    requestVoid(
+      `/api/admin/library/api-trackers/pins/${apiTrackerPinPathID(id)}/scan`,
+      { method: "POST" },
+    ),
+  listAPITrackerDownloads: (id: string, limit = 50) => {
+    const safeLimit = Math.max(1, Math.min(500, Math.trunc(limit) || 50));
+    return request<APITrackerDownload[]>(
+      `/api/admin/library/api-trackers/pins/${apiTrackerPinPathID(id)}/downloads?limit=${safeLimit}`,
     );
   },
 
@@ -895,6 +930,76 @@ export interface FilenDownload {
   file_path?: string;
   size_bytes: number;
   status: FilenDownloadStatus;
+  error?: string;
+  track_id?: string;
+  metadata?: Record<string, unknown>;
+  first_seen_at: string;
+  downloaded_at?: string | null;
+  updated_at: string;
+}
+
+export interface APITrackerPin {
+  id: string;
+  root_id?: string;
+  root_path: string;
+  destination_subdir: string;
+  destination_path: string;
+  api_base_url: string;
+  tracker_id: number;
+  tracker_name: string;
+  tracker_url: string;
+  tab: string;
+  label: string;
+  primary_artist: string;
+  enabled: boolean;
+  scan_interval_seconds: number;
+  last_scan_at?: string | null;
+  last_success_at?: string | null;
+  last_error?: string;
+  created_at: string;
+  updated_at: string;
+  root_exists: boolean;
+}
+
+export interface APITrackerPinCreate {
+  root_id?: string;
+  root_path?: string;
+  destination_subdir?: string;
+  api_base_url?: string;
+  tracker?: string;
+  tracker_id?: string | number;
+  tracker_url?: string;
+  tracker_name?: string;
+  tab?: string;
+  label?: string;
+  primary_artist?: string;
+  enabled?: boolean;
+  scan_interval_seconds?: number;
+}
+
+export interface APITrackerPinPatch {
+  destination_subdir?: string;
+  tab?: string;
+  label?: string;
+  primary_artist?: string;
+  enabled?: boolean;
+  scan_interval_seconds?: number;
+}
+
+export type APITrackerDownloadStatus =
+  | "downloaded"
+  | "existing"
+  | "skipped"
+  | "failed";
+
+export interface APITrackerDownload {
+  id: number;
+  pin_id: string;
+  entry_id?: number;
+  source_url: string;
+  resolved_url?: string;
+  file_path?: string;
+  status: APITrackerDownloadStatus;
   error?: string;
   track_id?: string;
   metadata?: Record<string, unknown>;

--- a/frontend/src/lib/discordPresence.ts
+++ b/frontend/src/lib/discordPresence.ts
@@ -117,20 +117,21 @@ export function useDiscordPresence() {
 }
 
 /**
- * Resolve the cover URL to ship with a Discord activity push. Discord's media
- * proxy fetches `large_image` server-side without the user's cookies, so the
- * normal auth-gated cover endpoints 404 on it. We ask the backend to mint a
- * short-lived signed public URL instead, cache it per album, and hand
- * Electron an absolute URL it can host-rewrite to the public backend.
+ * Resolve the cover URL to ship with a Discord activity push. Remote sources
+ * such as TIDAL already carry public HTTPS artwork URLs, so those can be
+ * passed straight through. Local covers need the signed backend path because
+ * Discord's media proxy fetches `large_image` server-side without user
+ * cookies.
  *
- * Returns undefined when the track has no album, the album has no cover, or
- * signing failed — Electron then falls back to the uploaded "lumen" asset
+ * Returns undefined when the track has no usable cover or signing failed;
+ * Electron then falls back to the uploaded "lumen" asset
  * key on Discord's side.
  */
 async function resolveSignedCoverUrl(
   track: TrackListItem,
   cache: Map<string, SignedCoverCacheEntry>,
 ): Promise<string | undefined> {
+  if (track.cover_url) return toAbsolute(track.cover_url);
   if (!track.album_id) return undefined;
   const nowSec = Math.floor(Date.now() / 1000);
   const cached = cache.get(track.album_id);

--- a/frontend/src/pages/AdminLibrary.tsx
+++ b/frontend/src/pages/AdminLibrary.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api, errorMessage, type MusicRoot } from "../api";
+import { APITrackerPinsSection } from "./admin/APITrackerPinsSection";
 import { ArtistGridPinsSection } from "./admin/ArtistGridPinsSection";
 import { FilenPinsSection } from "./admin/FilenPinsSection";
 import { MusicRootsSection } from "./admin/MusicRootsSection";
@@ -55,6 +56,11 @@ export function LibraryAdminSection() {
         onError={onError}
       />
       <TidalSection />
+      <APITrackerPinsSection
+        rootOptions={rootOptions}
+        defaultRootPath={defaultRootPath}
+        onError={onError}
+      />
       <ArtistGridPinsSection
         rootOptions={rootOptions}
         defaultRootPath={defaultRootPath}

--- a/frontend/src/pages/admin/APITrackerPinsSection.tsx
+++ b/frontend/src/pages/admin/APITrackerPinsSection.tsx
@@ -1,0 +1,260 @@
+import { FormEvent, useState } from "react";
+import { LinkIcon } from "@heroicons/react/16/solid";
+import {
+  api,
+  errorMessage,
+  type APITrackerDownload,
+  type APITrackerPin,
+} from "../../api";
+import { Button } from "../../components/Button";
+import { Field, TextInput } from "../../components/Field";
+import { Select } from "../../components/Select";
+import { AdminSectionIntro } from "./AdminSectionTitle";
+import { DownloadHistoryTable, PinTable } from "./PinComponents";
+import { usePinManager } from "./usePinManager";
+
+type RootOption = { value: string; label: string; disabled: boolean };
+
+export function APITrackerPinsSection({
+  rootOptions,
+  defaultRootPath,
+  onError,
+}: {
+  rootOptions: RootOption[];
+  defaultRootPath: string;
+  onError: (message: string) => void;
+}) {
+  const manager = usePinManager<APITrackerPin, APITrackerDownload>({
+    list: () => api.listAPITrackerPins(),
+    update: (id, patch) => api.updateAPITrackerPin(id, patch),
+    remove: (id) => api.deleteAPITrackerPin(id),
+    scan: (id) => api.scanAPITrackerPin(id),
+    listDownloads: (id, limit) => api.listAPITrackerDownloads(id, limit),
+    kind: "API tracker",
+    confirmRemove: (pin) =>
+      `Remove API tracker ${pin.label || pin.tracker_name || pin.tracker_id}?\n\nDownloaded files stay on disk and remain in the library.`,
+    onError,
+  });
+
+  const [rootPath, setRootPath] = useState("");
+  const [tracker, setTracker] = useState("");
+  const [apiBaseURL, setApiBaseURL] = useState("");
+  const [destinationSubdir, setDestinationSubdir] = useState("");
+  const [tab, setTab] = useState("");
+  const [label, setLabel] = useState("");
+  const [primaryArtist, setPrimaryArtist] = useState("");
+  const [scanMinutes, setScanMinutes] = useState("60");
+  const [adding, setAdding] = useState(false);
+
+  const effectiveRootPath = rootPath || defaultRootPath;
+
+  const addPin = async (e: FormEvent) => {
+    e.preventDefault();
+    onError("");
+    setAdding(true);
+    try {
+      const interval = Math.max(5, Number.parseInt(scanMinutes, 10) || 60);
+      await api.createAPITrackerPin({
+        root_path: effectiveRootPath,
+        destination_subdir: destinationSubdir.trim(),
+        api_base_url: apiBaseURL.trim(),
+        tracker: tracker.trim(),
+        tab: tab.trim(),
+        label: label.trim(),
+        primary_artist: primaryArtist.trim(),
+        scan_interval_seconds: interval * 60,
+      });
+      setTracker("");
+      setApiBaseURL("");
+      setDestinationSubdir("");
+      setTab("");
+      setLabel("");
+      setPrimaryArtist("");
+      setScanMinutes("60");
+      await manager.reload();
+    } catch (err) {
+      onError(errorMessage(err, "Failed to pin API tracker."));
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const historyPin = manager.historyPinID
+    ? manager.pins?.find((pin) => pin.id === manager.historyPinID)
+    : undefined;
+  const historyRows = manager.historyPinID
+    ? manager.downloadsByPin[manager.historyPinID]
+    : undefined;
+
+  return (
+    <section aria-labelledby="api-tracker-pins" style={{ display: "grid", gap: 14 }}>
+      <AdminSectionIntro
+        id="api-tracker-pins"
+        title="API trackers"
+        description="Pin Tracker API catalogs to configured sources. Scans pull linked audio from tracker entries and ingest downloaded files into the library."
+      />
+
+      <form
+        onSubmit={addPin}
+        className="surface"
+        style={{ padding: 20, display: "grid", gap: 14 }}
+      >
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+            gap: 12,
+          }}
+        >
+          <Field
+            label="Tracker URL or ID"
+            hint="Tracker API /v1/trackers/:id link or raw id"
+          >
+            <TextInput
+              value={tracker}
+              onChange={(e) => setTracker(e.target.value)}
+              placeholder="https://trackers.musicfiles.su/api/v1/trackers/1"
+              required
+            />
+          </Field>
+          <Field label="Source folder">
+            <Select
+              value={effectiveRootPath}
+              onChange={setRootPath}
+              options={rootOptions}
+              placeholder="Select source folder"
+              disabled={!rootOptions.length}
+            />
+          </Field>
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+            gap: 12,
+          }}
+        >
+          <Field label="API base URL" hint="Optional">
+            <TextInput
+              value={apiBaseURL}
+              onChange={(e) => setApiBaseURL(e.target.value)}
+              placeholder="https://trackers.musicfiles.su/api"
+            />
+          </Field>
+          <Field label="Destination subfolder" hint="Relative to the selected source">
+            <TextInput
+              value={destinationSubdir}
+              onChange={(e) => setDestinationSubdir(e.target.value)}
+              placeholder="API Trackers"
+            />
+          </Field>
+          <Field label="Tab" hint="Optional sheet name">
+            <TextInput
+              value={tab}
+              onChange={(e) => setTab(e.target.value)}
+              placeholder="Leaks"
+            />
+          </Field>
+          <Field label="Primary artist" hint="Optional override">
+            <TextInput
+              value={primaryArtist}
+              onChange={(e) => setPrimaryArtist(e.target.value)}
+              placeholder="Artist"
+            />
+          </Field>
+          <Field label="Every" hint="Minutes">
+            <TextInput
+              type="number"
+              min={5}
+              step={5}
+              value={scanMinutes}
+              onChange={(e) => setScanMinutes(e.target.value)}
+            />
+          </Field>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "end",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
+          <div style={{ flex: "1 1 260px" }}>
+            <Field label="Label" hint="Optional display name">
+              <TextInput
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="API tracker"
+              />
+            </Field>
+          </div>
+          <Button
+            type="submit"
+            variant="primary"
+            leadingIcon={<LinkIcon className="size-4" />}
+            disabled={adding || !tracker.trim() || !effectiveRootPath}
+          >
+            {adding ? "Pinning..." : "Pin tracker"}
+          </Button>
+        </div>
+      </form>
+
+      <PinTable
+        manager={manager}
+        nameHeader="Tracker"
+        emptyLabel="No API tracker pins yet."
+        rowKey={(pin) =>
+          (pin.id?.trim() ?? "") ||
+          `${pin.api_base_url}:${pin.tracker_id}:${pin.destination_path}`
+        }
+        renderLead={(pin) => (
+          <>
+            <td>
+              <div className="track-title">
+                {pin.label || pin.tracker_name || `Tracker ${pin.tracker_id}`}
+              </div>
+              <div className="track-sub mono" style={{ wordBreak: "break-all" }}>
+                {pin.api_base_url}/v1/trackers/{pin.tracker_id}
+              </div>
+              {pin.tab && <div className="track-sub">Tab: {pin.tab}</div>}
+              {pin.primary_artist && (
+                <div className="track-sub">{pin.primary_artist}</div>
+              )}
+            </td>
+            <td className="mono" style={{ wordBreak: "break-all" }}>
+              {pin.destination_path}
+              {!pin.root_exists && (
+                <span
+                  title="The pinned source root does not exist on the server"
+                  style={{
+                    marginLeft: 8,
+                    color: "var(--warning-fg)",
+                    fontSize: 11,
+                  }}
+                >
+                  missing
+                </span>
+              )}
+            </td>
+          </>
+        )}
+      />
+
+      {manager.historyPinID && (
+        <DownloadHistoryTable
+          title={
+            historyPin?.label ||
+            historyPin?.tracker_name ||
+            (historyPin ? `Tracker ${historyPin.tracker_id}` : "API tracker")
+          }
+          rows={historyRows}
+          sourceField="source_url"
+          onRefresh={() =>
+            manager.historyPinID && manager.loadDownloads(manager.historyPinID)
+          }
+        />
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
﻿## Summary

- Add API tracker pin support to the admin Library UI, shared API client, and backend pin APIs.
- Allow API tracker pins to target a specific sheet tab and include tab details in scanner metadata.
- Fetch tracker era images, store them as cover art, and apply them to ingested or existing tracks' albums.
- Move API tracker defaults and docs from trackers.misleadi.ng to trackers.musicfiles.su.
- Update migrations for the API tracker base URL, tab-aware uniqueness, and soft-delete-aware track SHA uniqueness.
- Prefer public cover URLs for Discord presence before falling back to signed local cover URLs.

## Validation

- `go test ./...` in `backend` passed.
- `npm run build` in `frontend` passed.
- `npx tsc -p tsconfig.json --noEmit` in `core` was attempted, but the standalone core config currently lacks browser/DOM globals such as `RequestInit`, `fetch`, `FormData`, and `URLSearchParams`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin section for managing API tracker pins with create, update, delete, and scan operations
  * Album covers now automatically fetched and applied to downloaded tracks from API trackers
  * Added optional "tab" field to organize pins by sheet or category
  * New download history view for tracking individual pin downloads

* **Chores**
  * Updated API infrastructure to new domain endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->