### PR TITLE
[codex] Harden ingestion and surface tracker metadata

### DIFF
--- a/backend/docs/api-tracker.md
+++ b/backend/docs/api-tracker.md
@@ -1,75 +1,36 @@
-# Tracker API Reference
+# Tracker API Spec
 
-A read-mostly HTTP/JSON API over a catalog of TrackerHub-style spreadsheets
-(community song trackers). A Go service scrapes and normalizes the source
-spreadsheets into Postgres; this API exposes the normalized catalog plus a small
-admin surface for triggering refreshes.
+Base path: `/api`
 
-This document is implementation-complete: every endpoint, query parameter,
-response shape, status code, and behavior needed to reimplement the API on
-another stack is described below.
+When using the included system Nginx example, call the API through:
 
----
+```text
+http://your-host/api
+```
 
-## Base URL & ports
+When calling the Go service directly on the same machine:
 
-The service mounts everything under `/api`. There is no path rewriting in front
-of it — the upstream sees the full `/api/...` path.
+```text
+http://127.0.0.1:4444/api
+```
 
-| How you reach it | URL |
-| --- | --- |
-| **Production** | `https://trackers.musicfiles.su/api` |
-| Through the bundled Nginx (`backend/nginx/tracker.conf`, listens on `:80`) | `http://your-host/api` |
-| Directly against the Go service in Docker Compose | `http://127.0.0.1:4444/api` |
+## Auth
 
-The production deployment is served at `trackers.musicfiles.su`; call the API at
-`https://trackers.musicfiles.su/api/...` (e.g.
-`https://trackers.musicfiles.su/api/v1/trackers`).
+Read endpoints are public.
 
-The Go process binds `:$PORT`. The code default for `PORT` is `8080`; the
-provided `docker-compose.yml` sets `PORT=4444` and publishes it on
-`127.0.0.1:4444`. Nginx proxies `location /api/` to `127.0.0.1:4444` and
-everything else to the frontend on `127.0.0.1:9191`.
-
-All responses are sent with `Content-Type: application/json` (a single
-middleware sets this for every route, including errors).
-
----
-
-## Authentication
-
-- **Read endpoints are public** — no header required.
-- **Admin endpoints** require a bearer token:
-
-  ```http
-  Authorization: Bearer <ADMIN_API_KEY>
-  ```
-
-The expected value is compared exactly against the literal string
-`Bearer ` + `ADMIN_API_KEY`. The default development key is `dev-admin-key`. If
-`ADMIN_API_KEY` is empty, **all** admin requests are rejected (the endpoints
-become unreachable, never open).
-
-A missing or wrong token returns:
+Admin endpoints require:
 
 ```http
-HTTP/1.1 401 Unauthorized
-```
-```json
-{ "error": "missing or invalid bearer token" }
+Authorization: Bearer <ADMIN_API_KEY>
 ```
 
-Admin endpoints: `POST /api/v1/admin/refresh/global`,
-`POST /api/v1/admin/refresh/trackers/{id}`, `GET /api/v1/admin/jobs`,
-`GET /api/v1/admin/jobs/{id}`.
+`ADMIN_API_KEY` has no default and must be set, or the server refuses to start.
+For local development, set `DEV_MODE=true` to use the throwaway key
+`dev-admin-key`; production requires a real, strong key.
 
----
+## Common Responses
 
-## Conventions
-
-### Pagination envelope
-
-List endpoints that paginate return:
+Paginated endpoints return:
 
 ```json
 {
@@ -80,71 +41,55 @@ List endpoints that paginate return:
 }
 ```
 
-- `total` is the full count matching the filters (before `limit`/`offset`).
-- `items` is the current page.
-
-Two list endpoints are **not** truly paginated and return everything:
-- `GET /api/v1/trackers/lookup` → `{ "items": [...] }` (no limit/offset/total).
-- `GET /api/v1/trackers/{id}/sheets` → uses the envelope, but `limit` and
-  `total` both equal the number of sheets and `offset` is always `0`.
-
-### Pagination parameters
-
-| Name | Type | Default | Rules |
-| --- | --- | --- | --- |
-| `limit` | integer | `50` | Values `<= 0` become `50`; values `> 500` are clamped to `500`. |
-| `offset` | integer | `0` | Negative values become `0`. |
-
-Non-numeric values parse as `0` and therefore fall back to the defaults.
-
-### Filter parameter semantics
-
-- `era`, `type`, `quality`, `q` — whitespace-trimmed, **case-insensitive
-  partial match** (SQL `ILIKE '%value%'`).
-- `q` matches against the entry's combined search text **and** the tracker name.
-- `era` / `type` / `quality` match against that specific normalized field.
-- `has_links` — parsed as a boolean. Accepted truthy/falsy values follow Go's
-  `strconv.ParseBool`: `1, t, T, TRUE, true, True` and `0, f, F, FALSE, false,
-  False`. `true` keeps only entries with at least one link; `false` keeps only
-  entries with none. Any unparseable value is ignored (no filtering).
-- `tracker_id` (search only) — parsed as an integer; only applied when `> 0`.
-
-### Error shape
-
-Every error returns the same body:
+Errors return:
 
 ```json
-{ "error": "human-readable message" }
+{
+  "error": "message"
+}
 ```
 
-| Status | When |
-| --- | --- |
-| `400 Bad Request` | Path `{id}` is missing, non-numeric, or `<= 0` (`{"error":"invalid id"}`). |
-| `401 Unauthorized` | Admin route without a valid bearer token. |
-| `404 Not Found` | `GET /trackers/{id}` or `GET /admin/jobs/{id}` for an id that does not exist. |
-| `500 Internal Server Error` | Unexpected database/query failure. |
-| `503 Service Unavailable` | `GET /api/ready` when the database is unreachable. |
+## Health
 
-### HTTP methods
+### GET `/api/health`
 
-Routes are method-specific. Health is `GET`; reads are `GET`; admin refresh
-triggers are `POST`. Any other method on a known path yields the standard
-`405`/`404` from the Go router.
+Returns process liveness.
 
----
+```json
+{
+  "status": "ok"
+}
+```
 
-## Data models
+### GET `/api/ready`
 
-These are the JSON shapes returned by the API. `omitempty` means the field is
-absent from the response when empty/zero/null.
+Returns readiness. This checks database connectivity.
 
-### Tracker
+```json
+{
+  "status": "ready"
+}
+```
 
-One row of the TrackerHub master index plus derived metadata.
+## Trackers
+
+### GET `/api/v1/trackers`
+
+Lists TrackerHub trackers.
+
+Query parameters:
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `limit` | integer | `50` | Max `500`. |
+| `offset` | integer | `0` | Pagination offset. |
+
+Response item:
 
 ```json
 {
   "id": 1,
+  "source_key": "spreadsheet:1AbC...:1520634709|50 cent",
   "row": 4,
   "tracker_name": "50 Cent",
   "tracker_name_raw": "⭐ 50 Cent",
@@ -161,49 +106,31 @@ One row of the TrackerHub master index plus derived metadata.
   "gid": "...",
   "duplicate_of_row": null,
   "entry_count": 471,
-  "image_data_uri": "data:image/jpeg;base64,..."
+  "parse_status": "ok",
+  "last_parse_error": "",
+  "last_parsed_at": "2026-06-11T12:00:00Z",
+  "last_seen_at": "2026-06-11T12:00:00Z",
+  "missing_from_hub": false
 }
 ```
 
-| Field | Type | Notes |
-| --- | --- | --- |
-| `id` | integer | Internal database ID. Stable; use this for sub-resources. |
-| `row` | integer | Row number on the TrackerHub master sheet. |
-| `tracker_name` | string | Cleaned display name. |
-| `tracker_name_raw` | string | Original cell text (may include emoji/markers). |
-| `flags` | string[] | Derived flags, e.g. `best_of`. May be empty. |
-| `credits` | string | Credit text from the index. |
-| `credit_url` | string | Credit link, if any. |
-| `up_to_date` | string | Free-text status from the index (e.g. `Yes`). |
-| `working_links` | string | Free-text status from the index. |
-| `url` | string | Resolved spreadsheet URL. |
-| `original_url` | string | URL as written in the index. |
-| `resource_type` | string | e.g. `spreadsheet`. |
-| `resource_id` | string | Google resource ID. |
-| `spreadsheet_id` | string | Google spreadsheet ID. |
-| `gid` | string | Sheet gid within the spreadsheet. |
-| `duplicate_of_row` | integer \| null | Set when this row duplicates another. |
-| `entry_count` | integer | Parsed entries for this tracker. |
-| `image_data_uri` | string | `omitempty`. Base64 `data:` URI of the resolved artist image; present only when an image was fetched. Can be large. |
+`source_key` is the tracker's stable identity (Google resource + name);
+trackers are upserted on it, so `id` never gets reassigned to a different
+artist when the hub sheet reorders rows. `row` is display order only.
 
-> The `lookup` endpoint returns a leaner shape — see [Tracker lookup item](#tracker-lookup-item).
+`parse_status` is one of `never`, `ok`, `failed`, or `unsupported`. When
+`failed`, `last_parse_error` says why and the stored entries may be stale.
+`missing_from_hub` is `true` when the hub no longer lists the tracker.
 
-### Tracker lookup item
+### GET `/api/v1/trackers/{id}`
 
-Lean shape for typeahead / command-palette UIs. Never includes image bytes.
+Returns one tracker by internal database ID.
 
-```json
-{
-  "id": 1,
-  "tracker_name": "50 Cent",
-  "entry_count": 471,
-  "has_image": true
-}
-```
+### GET `/api/v1/trackers/{id}/sheets`
 
-### Sheet
+Lists parsed sheets for a tracker.
 
-A parsed tab within a tracker's spreadsheet.
+Response item:
 
 ```json
 {
@@ -216,11 +143,22 @@ A parsed tab within a tracker's spreadsheet.
 }
 ```
 
-### Entry
+### GET `/api/v1/trackers/{id}/entries`
 
-A single normalized row from a tracker sheet. The labeled fields below are typed
-as "any" because they are parsed from JSON cells and may be a string, number,
-boolean, null, or nested object depending on the source.
+Lists parsed entries for a tracker.
+
+Query parameters:
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `era` | string | none | Case-insensitive partial match. |
+| `type` | string | none | Case-insensitive partial match. |
+| `quality` | string | none | Case-insensitive partial match. |
+| `has_links` | boolean | none | `true` for entries with links, `false` for entries without links. |
+| `limit` | integer | `50` | Max `500`. |
+| `offset` | integer | `0` | Pagination offset. |
+
+Response item:
 
 ```json
 {
@@ -232,8 +170,6 @@ boolean, null, or nested object depending on the source.
   "sheet_name": "gid-1520634709",
   "row_number": 3,
   "era": "Before Power Of The Dollar",
-  "rec_era": "1999",
-  "rel_era": null,
   "name": "Song name",
   "notes": "Notes",
   "length": "3:12",
@@ -258,27 +194,156 @@ boolean, null, or nested object depending on the source.
 }
 ```
 
-| Field | Type | Notes |
-| --- | --- | --- |
-| `id` | integer | Internal entry ID. |
-| `tracker_id` | integer | Owning tracker. |
-| `tracker_name` | string | `omitempty`. Joined from the tracker. |
-| `tracker_url` | string | `omitempty`. Joined from the tracker. |
-| `sheet_id` | integer | Owning sheet. |
-| `sheet_name` | string | Sheet name. |
-| `row_number` | integer | Row index within the sheet. |
-| `era`, `rec_era`, `rel_era` | any | `omitempty`. Era / recording era / release era. |
-| `name`, `notes`, `length` | any | `omitempty`. |
-| `file_date`, `leak_date` | any | `omitempty`. |
-| `type`, `portion`, `quality` | any | `omitempty`. |
-| `links` | string[] | Always present; may be `[]`. |
-| `raw` | object | Original row keyed by the sheet's column headers. |
-| `fields` | object | Normalized field map (snake_case keys). |
-| `less_common_fields` | object | `omitempty`. Entries from `fields` whose keys are **not** one of the canonical fields (`era, rec_era, rel_era, name, notes, length, file_date, leak_date, type, portion, quality, links, raw, row_number`). Lets clients surface tracker-specific extra columns. |
+### GET `/api/v1/trackers/{id}/eras`
 
-### Job
+Era/album artwork found on the tracker's era-divider rows. One item per era
+that has an image.
 
-A refresh job (global or single-tracker).
+```json
+{
+  "items": [
+    {
+      "era": "Working On Dying",
+      "era_key": "working on dying",
+      "image_id": 12,
+      "image_url": "/api/v1/era-images/12"
+    }
+  ],
+  "total": 1
+}
+```
+
+### GET `/api/v1/era-images/{id}`
+
+Raw image bytes with the stored `Content-Type` and
+`Cache-Control: public, max-age=604800, immutable` (ids rotate on refresh).
+
+## Search
+
+### GET `/api/v1/search`
+
+Searches parsed entries across all trackers.
+
+Query parameters:
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `q` | string | none | Case-insensitive search across parsed text and tracker name. |
+| `tracker_id` | integer | none | Restrict results to a tracker ID. |
+| `era` | string | none | Case-insensitive partial match. |
+| `type` | string | none | Case-insensitive partial match. |
+| `quality` | string | none | Case-insensitive partial match. |
+| `has_links` | boolean | none | `true` or `false`. |
+| `limit` | integer | `50` | Max `500`. |
+| `offset` | integer | `0` | Pagination offset. |
+
+Returns the same entry shape as `/api/v1/trackers/{id}/entries`.
+
+Example:
+
+```text
+GET /api/v1/search?q=demo&quality=CD&has_links=true&limit=25
+```
+
+## Stats
+
+### GET `/api/v1/stats`
+
+Returns catalog counts.
+
+```json
+{
+  "trackers": 523,
+  "sheets": 500,
+  "entries": 10000,
+  "parse_errors": 12,
+  "failed_trackers": 3,
+  "never_parsed": 2,
+  "missing_from_hub": 1
+}
+```
+
+## Parse errors
+
+### GET `/api/v1/parse-errors`
+
+Requires the admin bearer token (`Authorization: Bearer <ADMIN_API_KEY>`).
+Lists current parse problems, newest first, in a pagination envelope:
+per-tracker parse failures, hub rows skipped during the last global refresh
+(`error_type: "hub_row_skipped"`), and sheets that contain data but parsed to
+0 entries (`error_type: "zero_entry_sheet"` — review items recorded even when
+the tracker's `parse_status` is `ok`). Cleared and re-evaluated per tracker on
+each successful parse.
+
+```json
+{
+  "id": 7,
+  "tracker_id": 42,
+  "tracker_name": "Avicii",
+  "source": "https://docs.google.com/spreadsheets/d/...",
+  "error_type": "*errors.errorString",
+  "error": "could not find a header row",
+  "created_at": "2026-06-11T12:00:00Z"
+}
+```
+
+## Admin Refresh
+
+### POST `/api/v1/admin/refresh/global`
+
+Queues or returns an already queued/running global refresh job.
+
+Requires admin auth.
+
+Response:
+
+```json
+{
+  "id": 1,
+  "scope": "global",
+  "tracker_id": null,
+  "status": "queued",
+  "requested_at": "2026-05-11T12:00:00Z"
+}
+```
+
+### POST `/api/v1/admin/refresh/trackers/{id}`
+
+Queues or returns an already queued/running refresh job for one tracker.
+
+Requires admin auth.
+
+## Admin Jobs
+
+### GET `/api/v1/admin/jobs`
+
+Lists refresh jobs.
+
+Requires admin auth.
+
+Query parameters:
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `limit` | integer | `50` | Max `500`. |
+| `offset` | integer | `0` | Pagination offset. |
+
+Job statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `queued` | Waiting to run. |
+| `running` | Currently executing. |
+| `succeeded` | Finished successfully. |
+| `failed` | Finished with an error. |
+
+### GET `/api/v1/admin/jobs/{id}`
+
+Returns one refresh job.
+
+Requires admin auth.
+
+Response:
 
 ```json
 {
@@ -293,272 +358,10 @@ A refresh job (global or single-tracker).
 }
 ```
 
-| Field | Type | Notes |
-| --- | --- | --- |
-| `id` | integer | Job ID. |
-| `scope` | string | `global` or `tracker`. |
-| `tracker_id` | integer \| null | `null` for global jobs. |
-| `status` | string | See status table below. |
-| `error` | string | `omitempty`. Present only on failure. |
-| `requested_at` | RFC 3339 timestamp | When the job was enqueued. |
-| `started_at` | RFC 3339 timestamp | `omitempty`. When it began running. |
-| `finished_at` | RFC 3339 timestamp | `omitempty`. When it ended. |
+## Notes
 
-Job statuses:
+The first API boot with an empty database queues a global TrackerHub refresh. Global refresh also runs on `REFRESH_INTERVAL`, defaulting to `1h`.
 
-| Status | Meaning |
-| --- | --- |
-| `queued` | Waiting to run. |
-| `running` | Currently executing. |
-| `succeeded` | Finished successfully. |
-| `failed` | Finished with an error (see `error`). |
+Global refresh fetches and parses tracker spreadsheets concurrently. Configure concurrency with `REFRESH_WORKERS`; the default is `8`.
 
----
-
-## Endpoints
-
-### Health
-
-#### `GET /api/health`
-
-Process liveness. Always `200` if the process is up.
-
-```json
-{ "status": "ok" }
-```
-
-#### `GET /api/ready`
-
-Readiness — pings the database.
-
-- `200`: `{ "status": "ready" }`
-- `503`: `{ "error": "<db error>" }`
-
----
-
-### Trackers
-
-#### `GET /api/v1/trackers`
-
-Paginated list of trackers, ordered by `row` (TrackerHub master-sheet order).
-
-Query parameters: `limit`, `offset` (see [Pagination parameters](#pagination-parameters)).
-
-Returns a [pagination envelope](#pagination-envelope) of [Tracker](#tracker) items.
-
-#### `GET /api/v1/trackers/lookup`
-
-All trackers in the lean lookup shape, ordered by `row`. **Not paginated.**
-
-```json
-{
-  "items": [
-    { "id": 1, "tracker_name": "50 Cent", "entry_count": 471, "has_image": true }
-  ]
-}
-```
-
-> Routing note: `/trackers/lookup` is a distinct, more-specific route than
-> `/trackers/{id}`, so `lookup` is never treated as an id.
-
-#### `GET /api/v1/trackers/{id}`
-
-A single [Tracker](#tracker) by internal database ID.
-
-- `200`: the tracker object.
-- `400`: id not a positive integer.
-- `404`: no tracker with that id.
-
-#### `GET /api/v1/trackers/{id}/sheets`
-
-All [Sheet](#sheet) rows for a tracker, ordered by sheet ID. Returns the
-envelope, but it is not really paginated:
-
-```json
-{
-  "items": [ /* Sheet objects */ ],
-  "limit": 2,
-  "offset": 0,
-  "total": 2
-}
-```
-
-`limit` and `total` both equal the number of sheets returned.
-
-#### `GET /api/v1/trackers/{id}/entries`
-
-Paginated [Entry](#entry) list for one tracker, ordered by
-`(tracker row, sheet id, row number)`.
-
-Query parameters:
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `era` | string | none | Case-insensitive partial match. |
-| `type` | string | none | Case-insensitive partial match. |
-| `quality` | string | none | Case-insensitive partial match. |
-| `has_links` | boolean | none | Filter to entries with / without links. |
-| `limit` | integer | `50` | Max `500`. |
-| `offset` | integer | `0` | Pagination offset. |
-
-Returns a [pagination envelope](#pagination-envelope) of [Entry](#entry) items.
-(The `q` and `tracker_id` parameters are **not** read here — the tracker is taken
-from the path. Use `/search` for full-text or cross-tracker queries.)
-
----
-
-### Search
-
-#### `GET /api/v1/search`
-
-Search/normalize entries across all trackers. Same response shape and ordering
-as the per-tracker entries endpoint.
-
-Query parameters:
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `q` | string | none | Case-insensitive match across entry search text **and** tracker name. |
-| `tracker_id` | integer | none | Restrict to one tracker (applied only when `> 0`). |
-| `era` | string | none | Case-insensitive partial match. |
-| `type` | string | none | Case-insensitive partial match. |
-| `quality` | string | none | Case-insensitive partial match. |
-| `has_links` | boolean | none | Filter to entries with / without links. |
-| `limit` | integer | `50` | Max `500`. |
-| `offset` | integer | `0` | Pagination offset. |
-
-All filters combine with AND. Returns a [pagination envelope](#pagination-envelope)
-of [Entry](#entry) items.
-
-Example:
-
-```text
-GET /api/v1/search?q=demo&quality=CD&has_links=true&limit=25
-```
-
----
-
-### Stats
-
-#### `GET /api/v1/stats`
-
-Catalog-wide counts.
-
-```json
-{
-  "trackers": 523,
-  "sheets": 500,
-  "entries": 10000,
-  "parse_errors": 12
-}
-```
-
-`parse_errors` is the number of recorded parse failures (see
-[Refresh & parsing behavior](#refresh--parsing-behavior)).
-
----
-
-### Admin — Refresh
-
-Both require admin auth and respond with **`202 Accepted`** and a [Job](#job).
-
-Enqueue is **idempotent per scope**: if a `queued` or `running` job already
-exists for the same scope (and same tracker, for tracker scope), that existing
-job is returned instead of creating a duplicate.
-
-#### `POST /api/v1/admin/refresh/global`
-
-Queues (or returns the in-flight) global refresh of the whole TrackerHub index.
-
-```json
-{
-  "id": 1,
-  "scope": "global",
-  "tracker_id": null,
-  "status": "queued",
-  "requested_at": "2026-05-11T12:00:00Z"
-}
-```
-
-#### `POST /api/v1/admin/refresh/trackers/{id}`
-
-Queues (or returns the in-flight) refresh for a single tracker.
-
-- `202`: the job.
-- `400`: id not a positive integer.
-
----
-
-### Admin — Jobs
-
-Both require admin auth.
-
-#### `GET /api/v1/admin/jobs`
-
-Paginated [Job](#job) list, newest first (ordered by descending ID).
-
-Query parameters: `limit`, `offset`. Returns a [pagination envelope](#pagination-envelope).
-
-#### `GET /api/v1/admin/jobs/{id}`
-
-A single [Job](#job).
-
-- `200`: the job.
-- `400`: id not a positive integer.
-- `404`: no job with that id.
-
----
-
-## Refresh & parsing behavior
-
-Background behavior a reimplementation should reproduce:
-
-- **First boot.** On startup, after running database migrations, if the catalog
-  is empty a global refresh is enqueued automatically.
-- **Scheduled refresh.** A global refresh is enqueued every `REFRESH_INTERVAL`
-  (default `1h`).
-- **Worker.** A background worker claims `queued` jobs one at a time (FIFO by ID,
-  using `FOR UPDATE SKIP LOCKED`), marks them `running` with `started_at`, then
-  `succeeded` / `failed` with `finished_at`.
-- **Concurrency.** A global refresh fetches and parses individual tracker
-  spreadsheets concurrently, with `REFRESH_WORKERS` workers (default `8`).
-- **Failure handling.** Per-tracker parse failures are recorded in the
-  `parse_errors` table and surfaced via `/stats`. A global refresh continues past
-  individual tracker failures unless `FAIL_FAST_REFRESH=true`.
-
----
-
-## Configuration
-
-Environment variables read by the Go service:
-
-| Variable | Default (code) | Purpose |
-| --- | --- | --- |
-| `DATABASE_URL` | `postgres://tracker:tracker@postgres:5432/tracker?sslmode=disable` | Postgres connection string. |
-| `ADMIN_API_KEY` | `dev-admin-key` | Bearer token for admin endpoints. Empty disables admin access entirely. |
-| `PORT` | `8080` | HTTP listen port. (`docker-compose.yml` sets `4444`.) |
-| `TRACKERHUB_URL` | TrackerHub master spreadsheet URL | Source index to scrape. |
-| `REFRESH_INTERVAL` | `1h` | Global refresh cadence. Accepts a Go duration (`30m`, `2h`) or a plain integer (seconds). |
-| `REQUEST_TIMEOUT` | `60s` | Outbound fetch timeout. |
-| `REFRESH_WORKERS` | `8` | Concurrent per-tracker fetch/parse workers (minimum `1`). |
-| `FAIL_FAST_REFRESH` | `false` | If `true`, abort a refresh on the first tracker failure. |
-
----
-
-## Quick reference
-
-| Method | Path | Auth | Returns |
-| --- | --- | --- | --- |
-| GET | `/api/health` | — | `{ status }` |
-| GET | `/api/ready` | — | `{ status }` or `503` |
-| GET | `/api/v1/trackers` | — | Page of Tracker |
-| GET | `/api/v1/trackers/lookup` | — | `{ items: TrackerLookup[] }` |
-| GET | `/api/v1/trackers/{id}` | — | Tracker |
-| GET | `/api/v1/trackers/{id}/sheets` | — | Envelope of Sheet (all) |
-| GET | `/api/v1/trackers/{id}/entries` | — | Page of Entry |
-| GET | `/api/v1/search` | — | Page of Entry |
-| GET | `/api/v1/stats` | — | `{ trackers, sheets, entries, parse_errors }` |
-| POST | `/api/v1/admin/refresh/global` | Bearer | Job (`202`) |
-| POST | `/api/v1/admin/refresh/trackers/{id}` | Bearer | Job (`202`) |
-| GET | `/api/v1/admin/jobs` | Bearer | Page of Job |
-| GET | `/api/v1/admin/jobs/{id}` | Bearer | Job |
+Tracker parsing stores parse failures in `parse_errors`; a global refresh continues after individual tracker failures unless `FAIL_FAST_REFRESH=true`.

--- a/backend/filen-downloader/index.mjs
+++ b/backend/filen-downloader/index.mjs
@@ -2,6 +2,8 @@
 import { FilenSDK } from "@filen/sdk"
 import path from "node:path"
 import fs from "node:fs/promises"
+import { constants as fsConstants } from "node:fs"
+import { randomUUID } from "node:crypto"
 
 function usage() {
   console.error("Usage: node index.mjs [--json] [--password <pw> | --password-env <name>] <filen-share-url> <outDir>")
@@ -126,6 +128,57 @@ async function nextAvailablePath(outDir, target) {
   return resolveInside(outDir, `${base}-${Date.now()}${ext}`)
 }
 
+function isExistError(err) {
+  return err?.code === "EEXIST"
+}
+
+async function tempPathForTarget(outDir, target) {
+  return resolveInside(outDir, path.join(path.dirname(target), `.${path.basename(target)}.${randomUUID()}.part`))
+}
+
+async function assertCompleteDownload(tmpPath, expectedSize) {
+  const st = await fs.stat(tmpPath)
+  if (!st.isFile()) {
+    throw new Error("download target is not a regular file")
+  }
+  if (expectedSize > 0 && st.size !== expectedSize) {
+    throw new Error(`download size mismatch: expected ${expectedSize} bytes, got ${st.size}`)
+  }
+  if (st.size <= 0) {
+    throw new Error("download produced an empty file")
+  }
+}
+
+async function installNoOverwrite(outDir, tmpPath, target) {
+  target = resolveInside(outDir, target)
+  for (let i = 0; i < 10000; i++) {
+    try {
+      await fs.link(tmpPath, target)
+      await fs.rm(tmpPath, { force: true })
+      return target
+    } catch (err) {
+      if (isExistError(err)) {
+        target = await nextAvailablePath(outDir, target)
+        continue
+      }
+    }
+
+    try {
+      await fs.copyFile(tmpPath, target, fsConstants.COPYFILE_EXCL)
+      await fs.rm(tmpPath, { force: true })
+      return target
+    } catch (err) {
+      if (isExistError(err)) {
+        target = await nextAvailablePath(outDir, target)
+        continue
+      }
+      await fs.rm(target, { force: true }).catch(() => {})
+      throw err
+    }
+  }
+  throw new Error("could not find an available target path")
+}
+
 async function prepareTarget(outDir, target, size) {
   target = resolveInside(outDir, target)
   const st = await statOrNull(target)
@@ -176,16 +229,24 @@ async function downloadSingleFile(cloud, linkUuid, linkKey, password, outDir) {
   }
   try {
     await fs.mkdir(path.dirname(target.path), { recursive: true })
-    await cloud.downloadFileToLocal({
-      uuid: info.uuid,
-      bucket: info.bucket,
-      region: info.region,
-      chunks: info.chunks,
-      version: info.version,
-      key: linkKey,
-      size: info.size,
-      to: target.path
-    })
+    const tmpPath = await tempPathForTarget(outDir, target.path)
+    try {
+      await cloud.downloadFileToLocal({
+        uuid: info.uuid,
+        bucket: info.bucket,
+        region: info.region,
+        chunks: info.chunks,
+        version: info.version,
+        key: linkKey,
+        size: info.size,
+        to: tmpPath
+      })
+      await assertCompleteDownload(tmpPath, info.size)
+      target.path = await installNoOverwrite(outDir, tmpPath, target.path)
+    } catch (err) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {})
+      throw err
+    }
     emit({ event: "file", status: "downloaded", relPath, path: target.path, size: info.size })
   } catch (err) {
     if (readOnlyError(err)) {
@@ -203,7 +264,7 @@ async function downloadSingleFile(cloud, linkUuid, linkKey, password, outDir) {
       event: "file",
       status: "failed",
       relPath,
-      path: target.path,
+      path: "",
       size: info.size,
       error: String(err?.message ?? err)
     })
@@ -290,7 +351,15 @@ async function downloadFolderLink(cloud, linkUuid, linkKey, password, outDir) {
     }
     try {
       await fs.mkdir(path.dirname(target.path), { recursive: true })
-      await cloud.downloadFileToLocal({ ...job.params, to: target.path })
+      const tmpPath = await tempPathForTarget(outDir, target.path)
+      try {
+        await cloud.downloadFileToLocal({ ...job.params, to: tmpPath })
+        await assertCompleteDownload(tmpPath, job.size)
+        target.path = await installNoOverwrite(outDir, tmpPath, target.path)
+      } catch (err) {
+        await fs.rm(tmpPath, { force: true }).catch(() => {})
+        throw err
+      }
       emit({ event: "file", status: "downloaded", relPath: job.relPath, path: target.path, size: job.size })
     } catch (err) {
       if (readOnlyError(err)) {
@@ -309,7 +378,7 @@ async function downloadFolderLink(cloud, linkUuid, linkKey, password, outDir) {
         event: "file",
         status: "failed",
         relPath: job.relPath,
-        path: target.path,
+        path: "",
         size: job.size,
         error: String(err?.message ?? err)
       })

--- a/backend/internal/apitracker/scanner.go
+++ b/backend/internal/apitracker/scanner.go
@@ -72,6 +72,8 @@ type TrackContext struct {
 	Album       string
 	Year        int
 	Genre       string
+	Composer    string
+	Comment     string
 	Featured    []string
 }
 
@@ -567,6 +569,12 @@ func (s *Scanner) applyTrackerMetadata(ctx context.Context, trackID uuid.UUID, t
 	if tc.Genre != "" {
 		patch.Genre = &tc.Genre
 	}
+	if tc.Composer != "" {
+		patch.Composer = &tc.Composer
+	}
+	if tc.Comment != "" {
+		patch.Comments = &tc.Comment
+	}
 	if len(artists) > 0 {
 		patch.Artists = &artists
 	}
@@ -618,6 +626,12 @@ func BuildContext(tracker Tracker, pin Pin, entry Entry) TrackContext {
 	if title == "" {
 		title = "Unknown"
 	}
+	cleanTitle, fallbackProducer, altTitle, fallbackFeatured := parseTitleCredits(title, apiTrackerExtraText(entry))
+	if cleanTitle != "" {
+		title = cleanTitle
+	}
+	producer := firstNonEmpty(apiTrackerProducer(entry), fallbackProducer)
+	featured := dedupeStrings(append(apiTrackerFeatured(entry), fallbackFeatured...))
 	era := firstNonEmpty(
 		anyString(entry.Era),
 		anyString(entry.RecEra),
@@ -633,13 +647,24 @@ func BuildContext(tracker Tracker, pin Pin, entry Entry) TrackContext {
 		anyString(entry.LeakDate),
 		era,
 	)
+	artist := primary
+	if len(featured) > 0 {
+		artist = primary + " feat. " + strings.Join(featured, ", ")
+	}
+	commentParts := []string{}
+	if altTitle != "" {
+		commentParts = append(commentParts, "Alt title: "+altTitle)
+	}
 	return TrackContext{
 		Title:       title,
-		Artist:      primary,
+		Artist:      artist,
 		AlbumArtist: primary,
 		Album:       era,
 		Year:        year,
 		Genre:       genre,
+		Composer:    producer,
+		Comment:     strings.Join(commentParts, "\n\n"),
+		Featured:    featured,
 	}
 }
 
@@ -659,6 +684,8 @@ func entryMetadata(tracker Tracker, pin Pin, entry Entry, tc TrackContext) json.
 		"type":           anyString(entry.Type),
 		"quality":        anyString(entry.Quality),
 		"primary_artist": tc.AlbumArtist,
+		"featured":       tc.Featured,
+		"producer":       tc.Composer,
 	})
 	if err != nil {
 		return json.RawMessage(`{}`)
@@ -826,6 +853,161 @@ func contentTypeExt(ct string) string {
 	return ""
 }
 
+func apiTrackerExtraText(entry Entry) string {
+	parts := []string{
+		fieldString(entry.Fields, "extra"),
+		fieldString(entry.Fields, "description"),
+		fieldString(entry.Fields, "notes"),
+		fieldString(entry.Raw, "extra"),
+		fieldString(entry.Raw, "description"),
+		fieldString(entry.Raw, "notes"),
+	}
+	for _, key := range []string{"extra", "description", "notes"} {
+		parts = append(parts, strings.Join(fieldStrings(entry.LessCommonFields, key), " "))
+	}
+	return strings.Join(parts, " ")
+}
+
+func apiTrackerProducer(entry Entry) string {
+	for _, key := range []string{"producer", "producers", "prod", "produced_by", "produced by"} {
+		values := fieldStrings(entry.LessCommonFields, key)
+		for i := range values {
+			values[i] = strings.TrimSpace(apiTrackerProdRe.ReplaceAllString(values[i], ""))
+		}
+		if value := strings.Join(nonEmptyStrings(values), ", "); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func apiTrackerFeatured(entry Entry) []string {
+	out := []string{}
+	for _, key := range []string{"featured", "features", "feature", "feat", "feats", "featuring", "ft"} {
+		for _, value := range fieldStrings(entry.LessCommonFields, key) {
+			out = append(out, splitCreditNames(apiTrackerFeatRe.ReplaceAllString(value, ""))...)
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func parseTitleCredits(title string, extraText string) (cleanTitle string, producer string, altTitle string, featured []string) {
+	cleanTitle = strings.TrimSpace(title)
+	for _, m := range apiTrackerCreditGroupRe.FindAllStringSubmatch(title+" "+extraText, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		group := strings.TrimSpace(m[1])
+		if group == "" {
+			continue
+		}
+		switch {
+		case apiTrackerProdRe.MatchString(group):
+			if producer == "" {
+				producer = strings.TrimSpace(apiTrackerProdRe.ReplaceAllString(group, ""))
+			}
+			cleanTitle = strings.TrimSpace(strings.Replace(cleanTitle, m[0], "", 1))
+		case apiTrackerFeatRe.MatchString(group):
+			names := splitCreditNames(apiTrackerFeatRe.ReplaceAllString(group, ""))
+			featured = append(featured, names...)
+			cleanTitle = strings.TrimSpace(strings.Replace(cleanTitle, m[0], "", 1))
+		case altTitle == "" && strings.Contains(title, m[0]):
+			altTitle = group
+		}
+	}
+	cleanTitle = strings.Join(strings.Fields(cleanTitle), " ")
+	return cleanTitle, producer, altTitle, dedupeStrings(featured)
+}
+
+func splitCreditNames(raw string) []string {
+	raw = strings.NewReplacer(
+		"&", ",",
+		" x ", ",",
+		" X ", ",",
+		" feat. ", ",",
+		" feat ", ",",
+		" ft. ", ",",
+		" ft ", ",",
+		" featuring ", ",",
+	).Replace(raw)
+	parts := strings.Split(raw, ",")
+	out := []string{}
+	for _, part := range parts {
+		for _, name := range strings.Split(part, " and ") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				out = append(out, name)
+			}
+		}
+	}
+	return out
+}
+
+func fieldStrings(fields map[string]any, key string) []string {
+	if fields == nil {
+		return nil
+	}
+	for k, value := range fields {
+		if strings.EqualFold(strings.TrimSpace(k), key) {
+			return valueStrings(value)
+		}
+	}
+	return nil
+}
+
+func valueStrings(value any) []string {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if item = strings.TrimSpace(item); item != "" {
+				out = append(out, item)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, valueStrings(item)...)
+		}
+		return out
+	default:
+		if s := anyString(v); s != "" {
+			return []string{s}
+		}
+		return nil
+	}
+}
+
+func dedupeStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := values[:0]
+	for _, value := range values {
+		key := strings.ToLower(strings.TrimSpace(value))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, strings.TrimSpace(value))
+	}
+	return out
+}
+
+func nonEmptyStrings(values []string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
 func GuessPrimaryArtist(trackerName string) string {
 	name := strings.TrimSpace(trackerName)
 	for _, suffix := range []string{"Tracker", "Grid", "Sheet", "Spreadsheet", "List", "Leaks", "Archive", "Database"} {
@@ -874,7 +1056,12 @@ func firstYear(values ...string) int {
 	return 0
 }
 
-var yearPlainRe = regexp.MustCompile(`\b(?:19|20)\d{2}\b`)
+var (
+	yearPlainRe             = regexp.MustCompile(`\b(?:19|20)\d{2}\b`)
+	apiTrackerCreditGroupRe = regexp.MustCompile(`\(([^()]+)\)`)
+	apiTrackerProdRe        = regexp.MustCompile(`(?i)^(?:(?:prod|produced by)\.?)\s*`)
+	apiTrackerFeatRe        = regexp.MustCompile(`(?i)^(?:(?:feat|ft|featuring|w/|with)\.?)\s*`)
+)
 
 func ParseYear(text string) int {
 	if text == "" {

--- a/backend/internal/apitracker/scanner_test.go
+++ b/backend/internal/apitracker/scanner_test.go
@@ -79,6 +79,102 @@ func TestNormalizeEraKey(t *testing.T) {
 	}
 }
 
+func TestBuildContextExtractsTitleCredits(t *testing.T) {
+	ctx := BuildContext(
+		Tracker{TrackerName: "Future Tracker"},
+		Pin{},
+		Entry{Name: "Chrome Heart Cross (feat. Gunna) (prod. Wheezy)", Era: "Mixtape", Type: "Leak"},
+	)
+	if ctx.Title != "Chrome Heart Cross" {
+		t.Fatalf("Title = %q", ctx.Title)
+	}
+	if ctx.AlbumArtist != "Future" {
+		t.Fatalf("AlbumArtist = %q", ctx.AlbumArtist)
+	}
+	if ctx.Artist != "Future feat. Gunna" {
+		t.Fatalf("Artist = %q", ctx.Artist)
+	}
+	if len(ctx.Featured) != 1 || ctx.Featured[0] != "Gunna" {
+		t.Fatalf("Featured = %#v", ctx.Featured)
+	}
+	if ctx.Composer != "Wheezy" {
+		t.Fatalf("Composer = %q", ctx.Composer)
+	}
+}
+
+func TestBuildContextExtractsCreditsFromExtraFields(t *testing.T) {
+	ctx := BuildContext(
+		Tracker{TrackerName: "Future Tracker"},
+		Pin{},
+		Entry{
+			Name: "Too Comfortable",
+			Fields: map[string]any{
+				"extra": "(feat. Young Thug & Gunna) (prod. Wheezy)",
+			},
+		},
+	)
+	if ctx.Title != "Too Comfortable" {
+		t.Fatalf("Title = %q", ctx.Title)
+	}
+	if got := strings.Join(ctx.Featured, ", "); got != "Young Thug, Gunna" {
+		t.Fatalf("Featured = %#v", ctx.Featured)
+	}
+	if ctx.Composer != "Wheezy" {
+		t.Fatalf("Composer = %q", ctx.Composer)
+	}
+}
+
+func TestBuildContextUsesLessCommonCreditFields(t *testing.T) {
+	ctx := BuildContext(
+		Tracker{TrackerName: "Future Tracker"},
+		Pin{},
+		Entry{
+			Name: "Too Comfortable (feat. Drake)",
+			LessCommonFields: map[string]any{
+				"producer":  "Wheezy",
+				"featured":  []any{"Young Thug", "Gunna"},
+				"extra":     "(prod. should not win)",
+				"row_notes": "ignored",
+			},
+		},
+	)
+	if ctx.Title != "Too Comfortable" {
+		t.Fatalf("Title = %q", ctx.Title)
+	}
+	if ctx.Composer != "Wheezy" {
+		t.Fatalf("Composer = %q", ctx.Composer)
+	}
+	if got := strings.Join(ctx.Featured, ", "); got != "Young Thug, Gunna, Drake" {
+		t.Fatalf("Featured = %#v", ctx.Featured)
+	}
+	if ctx.Artist != "Future feat. Young Thug, Gunna, Drake" {
+		t.Fatalf("Artist = %q", ctx.Artist)
+	}
+}
+
+func TestBuildContextUsesLessCommonProducerWithoutTitleCredits(t *testing.T) {
+	ctx := BuildContext(
+		Tracker{TrackerName: "Future Tracker"},
+		Pin{},
+		Entry{
+			Name: "Solo",
+			LessCommonFields: map[string]any{
+				"produced_by": "Metro Boomin",
+				"featuring":   "Don Toliver & Travis Scott",
+			},
+		},
+	)
+	if ctx.Title != "Solo" {
+		t.Fatalf("Title = %q", ctx.Title)
+	}
+	if ctx.Composer != "Metro Boomin" {
+		t.Fatalf("Composer = %q", ctx.Composer)
+	}
+	if got := strings.Join(ctx.Featured, ", "); got != "Don Toliver, Travis Scott" {
+		t.Fatalf("Featured = %#v", ctx.Featured)
+	}
+}
+
 func TestDownloadOneRejectsLoopbackByDefaultBeforeRequest(t *testing.T) {
 	var requested bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/artistgrid/client.go
+++ b/backend/internal/artistgrid/client.go
@@ -500,8 +500,8 @@ var (
 	yearCopyrightRe = regexp.MustCompile(`(?:\x{2117}|\x{00a9})\s*(\d{4})`)
 	yearPlainRe     = regexp.MustCompile(`\b(?:19|20)\d{2}\b`)
 	extraGroupRe    = regexp.MustCompile(`\(([^()]+)\)`)
-	extraProdRe     = regexp.MustCompile(`(?i)^(?:prod\.?|produced by)\b\s*`)
-	extraFeatRe     = regexp.MustCompile(`(?i)^(?:feat\.?|ft\.?|featuring|w/|with)\b\s*`)
+	extraProdRe     = regexp.MustCompile(`(?i)^(?:(?:prod|produced by)\.?)\s*`)
+	extraFeatRe     = regexp.MustCompile(`(?i)^(?:(?:feat|ft|featuring|w/|with)\.?)\s*`)
 )
 
 func ParseYear(text string) int {

--- a/backend/internal/artistgrid/scanner.go
+++ b/backend/internal/artistgrid/scanner.go
@@ -469,6 +469,12 @@ func (s *Scanner) applyTrackerMetadata(ctx context.Context, trackID uuid.UUID, t
 	if tc.Genre != "" {
 		patch.Genre = &tc.Genre
 	}
+	if tc.Composer != "" {
+		patch.Composer = &tc.Composer
+	}
+	if tc.Comment != "" {
+		patch.Comments = &tc.Comment
+	}
 	if len(artists) > 0 {
 		patch.Artists = &artists
 	}

--- a/backend/internal/filen/scanner.go
+++ b/backend/internal/filen/scanner.go
@@ -238,10 +238,23 @@ func (s *Scanner) readEvents(ctx context.Context, pin Pin, destBase string, r io
 		}
 		var trackID *uuid.UUID
 		inserted := false
-		if (status == StatusDownloaded || status == StatusExisting) && ev.Path != "" {
-			trackID, inserted = s.ingestPath(ctx, ev.Path)
-			if inserted {
-				summary.Ingested++
+		if status == StatusDownloaded || status == StatusExisting {
+			if ev.Path == "" {
+				status = StatusFailed
+				if ev.Error == "" {
+					ev.Error = "helper did not provide file path"
+				}
+			} else if err := validateCompleteFile(ev.Path, ev.Size); err != nil {
+				status = StatusFailed
+				ev.Path = ""
+				if ev.Error == "" {
+					ev.Error = err.Error()
+				}
+			} else {
+				trackID, inserted = s.ingestPath(ctx, ev.Path)
+				if inserted {
+					summary.Ingested++
+				}
 			}
 		}
 		switch status {
@@ -291,6 +304,23 @@ func normalizeStatus(status string) string {
 	default:
 		return StatusFailed
 	}
+}
+
+func validateCompleteFile(p string, expectedSize int64) error {
+	info, err := os.Stat(p)
+	if err != nil {
+		return fmt.Errorf("downloaded file unavailable: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("downloaded path is not a regular file")
+	}
+	if expectedSize > 0 && info.Size() != expectedSize {
+		return fmt.Errorf("download size mismatch: expected %d bytes, got %d", expectedSize, info.Size())
+	}
+	if info.Size() <= 0 {
+		return fmt.Errorf("downloaded file is empty")
+	}
+	return nil
 }
 
 func eventMetadata(pin Pin, ev helperEvent) json.RawMessage {

--- a/backend/internal/filen/scanner_test.go
+++ b/backend/internal/filen/scanner_test.go
@@ -1,7 +1,9 @@
 package filen
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -46,5 +48,34 @@ func TestHelperPathInDestination(t *testing.T) {
 				t.Fatalf("helperPathInDestination returned non-absolute path %q", got)
 			}
 		})
+	}
+}
+
+func TestValidateCompleteFileRejectsSizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "song.mp3")
+	if err := os.WriteFile(p, []byte("partial"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := validateCompleteFile(p, int64(len("complete file")))
+	if err == nil {
+		t.Fatal("expected size mismatch error")
+	}
+	if !strings.Contains(err.Error(), "download size mismatch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateCompleteFileAcceptsMatchingSize(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "song.mp3")
+	data := []byte("complete file")
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateCompleteFile(p, int64(len(data))); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/backend/internal/filen/store.go
+++ b/backend/internal/filen/store.go
@@ -296,7 +296,8 @@ func (s *Store) RecordDownload(ctx context.Context, in DownloadInput) error {
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		ON CONFLICT (pin_id, source_path) DO UPDATE SET
 			file_path = CASE
-				WHEN EXCLUDED.file_path <> '' THEN EXCLUDED.file_path
+				WHEN EXCLUDED.status IN ('downloaded', 'existing') AND EXCLUDED.file_path <> '' THEN EXCLUDED.file_path
+				WHEN EXCLUDED.status IN ('failed', 'skipped') THEN ''
 				ELSE filen_downloads.file_path
 			END,
 			size_bytes = CASE

--- a/backend/internal/httpapi/handlers/tracks.go
+++ b/backend/internal/httpapi/handlers/tracks.go
@@ -86,6 +86,8 @@ type trackDetailResp struct {
 	DurationMS int               `json:"duration_ms"`
 	Genre      string            `json:"genre,omitempty"`
 	Year       int               `json:"year,omitempty"`
+	Composer   string            `json:"composer,omitempty"`
+	Comments   string            `json:"comments,omitempty"`
 	Format     string            `json:"format"`
 	Bitrate    int               `json:"bitrate,omitempty"`
 	SampleRate int               `json:"sample_rate,omitempty"`
@@ -327,6 +329,8 @@ func makeTrackDetailResp(t *library.TrackDetail, isFav bool) trackDetailResp {
 		DurationMS: t.DurationMS,
 		Genre:      t.Genre,
 		Year:       t.Year,
+		Composer:   t.Composer,
+		Comments:   t.Comments,
 		Format:     t.Format,
 		Bitrate:    t.Bitrate,
 		SampleRate: t.SampleRate,

--- a/backend/internal/ingest/watcher.go
+++ b/backend/internal/ingest/watcher.go
@@ -185,10 +185,26 @@ func (w *Watcher) handle(ctx context.Context, ev fsnotify.Event) {
 			w.schedule(ctx, ev.Name)
 		}
 	case ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
+		if w.svc.Library == nil {
+			return
+		}
 		if IsSupported(ev.Name) {
 			_ = w.svc.Library.SoftDeleteByPath(ctx, ev.Name)
 		}
+		if prefix := deletedTreePrefix(ev.Name); prefix != "" {
+			if _, err := w.svc.Library.SoftDeleteTracksUnderPath(ctx, prefix); err != nil {
+				w.svc.Logger.Warn("fsnotify subtree soft delete failed", "path", ev.Name, "err", err)
+			}
+		}
 	}
+}
+
+func deletedTreePrefix(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	return filepath.Clean(p) + string(os.PathSeparator)
 }
 
 // absorbDir walks `root`, registering watches for every subdirectory and

--- a/backend/internal/ingest/watcher_test.go
+++ b/backend/internal/ingest/watcher_test.go
@@ -1,0 +1,22 @@
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeletedTreePrefix(t *testing.T) {
+	p := filepath.Join("music", "tracker")
+	got := deletedTreePrefix(p)
+	want := filepath.Clean(p) + string(os.PathSeparator)
+	if got != want {
+		t.Fatalf("deletedTreePrefix() = %q, want %q", got, want)
+	}
+}
+
+func TestDeletedTreePrefixBlank(t *testing.T) {
+	if got := deletedTreePrefix("   "); got != "" {
+		t.Fatalf("deletedTreePrefix(blank) = %q, want empty", got)
+	}
+}

--- a/backend/internal/library/read.go
+++ b/backend/internal/library/read.go
@@ -19,6 +19,8 @@ type TrackDetail struct {
 	DurationMS   int
 	Genre        string
 	Year         int
+	Composer     string
+	Comments     string
 	Format       string
 	Bitrate      int
 	SampleRate   int
@@ -60,6 +62,7 @@ const trackDetailSelect = `
 		COALESCE(t.track_no, 0), COALESCE(t.disc_no, 0),
 		t.duration_ms,
 		COALESCE(t.genre, ''), COALESCE(t.year, 0),
+		COALESCE(t.composer, ''), COALESCE(t.comments, ''),
 		t.format,
 		COALESCE(t.bitrate, 0), COALESCE(t.sample_rate, 0), COALESCE(t.channels, 0),
 		t.file_path, t.file_size,
@@ -98,6 +101,7 @@ func (s *Store) getTrackDetail(ctx context.Context, query string, args ...any) (
 		&t.TrackNo, &t.DiscNo,
 		&t.DurationMS,
 		&t.Genre, &t.Year,
+		&t.Composer, &t.Comments,
 		&t.Format,
 		&t.Bitrate, &t.SampleRate, &t.Channels,
 		&t.FilePath, &t.FileSize,

--- a/backend/internal/library/store.go
+++ b/backend/internal/library/store.go
@@ -442,6 +442,8 @@ type TrackPatch struct {
 	Title       *string
 	Year        *int
 	Genre       *string
+	Composer    *string
+	Comments    *string
 	DiscNo      *int
 	TrackNo     *int
 	Artists     *[]string  // ordered; first is primary, rest featured
@@ -485,6 +487,12 @@ func (s *Store) UpdateTrack(ctx context.Context, id uuid.UUID, p TrackPatch) err
 	}
 	if p.Genre != nil {
 		set.Add("genre = NULLIF($%d, '')", *p.Genre)
+	}
+	if p.Composer != nil {
+		set.Add("composer = NULLIF($%d, '')", *p.Composer)
+	}
+	if p.Comments != nil {
+		set.Add("comments = NULLIF($%d, '')", *p.Comments)
 	}
 	if p.DiscNo != nil {
 		set.Add("disc_no = NULLIF($%d::int, 0)", *p.DiscNo)
@@ -635,8 +643,9 @@ func (s *Store) SetAlbumCover(ctx context.Context, albumID uuid.UUID, coverPath 
 	return nil
 }
 
-// SetTrackAlbumCover points the track's album at coverPath. It is
-// intentionally opportunistic: tracks without albums simply result in no rows
+// SetTrackAlbumCover points the track's album at coverPath when the album does
+// not already have local artwork. It is intentionally opportunistic: tracks
+// without albums, or albums that already have covers, simply result in no rows
 // updated.
 func (s *Store) SetTrackAlbumCover(ctx context.Context, trackID uuid.UUID, coverPath string) error {
 	coverPath = dbtext.Clean(coverPath)
@@ -648,7 +657,8 @@ func (s *Store) SetTrackAlbumCover(ctx context.Context, trackID uuid.UUID, cover
 		SET cover_art_path = $2, updated_at = NOW()
 		FROM tracks t
 		WHERE t.id = $1
-		  AND t.album_id = a.id`,
+		  AND t.album_id = a.id
+		  AND NULLIF(a.cover_art_path, '') IS NULL`,
 		trackID, coverPath)
 	return err
 }

--- a/core/src/api.ts
+++ b/core/src/api.ts
@@ -635,6 +635,8 @@ export interface TrackDetail {
   duration_ms: number;
   genre?: string;
   year?: number;
+  composer?: string;
+  comments?: string;
   format: string;
   bitrate?: number;
   sample_rate?: number;

--- a/frontend/src/components/TrackInfoDialog.tsx
+++ b/frontend/src/components/TrackInfoDialog.tsx
@@ -6,6 +6,7 @@ import { useTrackDetail } from "../lib/useTrackDetail";
 interface Props {
   open: boolean;
   trackId: string | null;
+  requestNonce?: number;
   onClose: () => void;
 }
 
@@ -16,8 +17,13 @@ interface Props {
  * separate from EditTrackDialog so non-admins can see the same information
  * without accidentally opening an editor they can't submit.
  */
-export function TrackInfoDialog({ open, trackId, onClose }: Props) {
-  const { track, error } = useTrackDetail(open, trackId);
+export function TrackInfoDialog({
+  open,
+  trackId,
+  requestNonce = 0,
+  onClose,
+}: Props) {
+  const { track, error } = useTrackDetail(open, trackId, requestNonce);
 
   const body = error ? (
     <div
@@ -39,27 +45,13 @@ export function TrackInfoDialog({ open, trackId, onClose }: Props) {
 
       <Section label="Identity">
         <Field k="Title" v={track.title} />
-        <Field
-          k="Artists"
-          v={
-            track.artists
-              .filter((a) => a.role !== "composer")
-              .map((a) => a.name)
-              .join(", ") || "—"
-          }
-        />
-        {track.artists.some((a) => a.role === "composer") && (
-          <Field
-            k="Composers"
-            v={track.artists
-              .filter((a) => a.role === "composer")
-              .map((a) => a.name)
-              .join(", ")}
-          />
-        )}
+        <Field k="Primary artist" v={artistNames(track, "primary") || "—"} />
+        <Field k="Featured" v={artistNames(track, "featured") || "—"} />
+        <Field k="Producers" v={producerNames(track) || "—"} />
         <Field k="Album" v={track.album_title || "—"} />
         <Field k="Year" v={track.year ? String(track.year) : "—"} />
         <Field k="Genre" v={track.genre || "—"} />
+        {track.comments && <Field k="Comments" v={track.comments} />}
         <Field
           k="Track · Disc"
           v={
@@ -128,6 +120,17 @@ function HeaderBlock({ track }: { track: TrackDetail }) {
       </div>
     </div>
   );
+}
+
+function artistNames(track: TrackDetail, role: string): string {
+  return track.artists
+    .filter((a) => a.role === role)
+    .map((a) => a.name)
+    .join(", ");
+}
+
+function producerNames(track: TrackDetail): string {
+  return track.composer?.trim() || artistNames(track, "composer");
 }
 
 function Section({

--- a/frontend/src/context/TrackInfo.tsx
+++ b/frontend/src/context/TrackInfo.tsx
@@ -22,14 +22,28 @@ const TrackInfoContext = createContext<TrackInfoCtxValue | null>(null);
  * entrypoints don't each need to manage their own copy.
  */
 export function TrackInfoProvider({ children }: { children: ReactNode }) {
-  const [id, setId] = useState<string | null>(null);
-  const open = useCallback((trackId: string) => setId(trackId), []);
-  const close = useCallback(() => setId(null), []);
+  const [request, setRequest] = useState<{ id: string; nonce: number } | null>(
+    null,
+  );
+  const open = useCallback(
+    (trackId: string) =>
+      setRequest((prev) => ({
+        id: trackId,
+        nonce: (prev?.nonce ?? 0) + 1,
+      })),
+    [],
+  );
+  const close = useCallback(() => setRequest(null), []);
   const value = useMemo<TrackInfoCtxValue>(() => ({ open }), [open]);
   return (
     <TrackInfoContext.Provider value={value}>
       {children}
-      <TrackInfoDialog open={id !== null} trackId={id} onClose={close} />
+      <TrackInfoDialog
+        open={request !== null}
+        trackId={request?.id ?? null}
+        requestNonce={request?.nonce ?? 0}
+        onClose={close}
+      />
     </TrackInfoContext.Provider>
   );
 }

--- a/frontend/src/lib/useTrackDetail.ts
+++ b/frontend/src/lib/useTrackDetail.ts
@@ -10,6 +10,7 @@ import { api, errorMessage, type TrackDetail } from "../api";
 export function useTrackDetail(
   open: boolean,
   trackId: string | null,
+  requestNonce = 0,
 ): { track: TrackDetail | null; error: string | null } {
   const [track, setTrack] = useState<TrackDetail | null>(null);
   const [error, setError] = useState<{
@@ -20,15 +21,28 @@ export function useTrackDetail(
   useEffect(() => {
     if (!open || !trackId) return;
     let cancelled = false;
+    let settled = false;
     const controller = new AbortController();
+    const timeout = window.setTimeout(() => {
+      if (cancelled || settled) return;
+      controller.abort();
+      setError({
+        trackId,
+        message: "Track info request timed out.",
+      });
+    }, 15000);
     setTrack(null);
     setError(null);
     api
       .getTrack(trackId, { signal: controller.signal })
       .then((t) => {
+        settled = true;
+        window.clearTimeout(timeout);
         if (!cancelled) setTrack(t);
       })
       .catch((err) => {
+        settled = true;
+        window.clearTimeout(timeout);
         if (!cancelled && !controller.signal.aborted) {
           setError({
             trackId,
@@ -38,12 +52,32 @@ export function useTrackDetail(
       });
     return () => {
       cancelled = true;
+      window.clearTimeout(timeout);
       controller.abort();
     };
-  }, [open, trackId]);
+  }, [open, trackId, requestNonce]);
 
   return {
-    track: open && track?.id === trackId ? track : null,
-    error: open && error?.trackId === trackId ? error.message : null,
+    track: open && track && trackMatchesRequest(track, trackId) ? track : null,
+    error:
+      open && error?.trackId === trackId
+        ? error.message
+        : open && track && !trackMatchesRequest(track, trackId)
+          ? "Loaded a different track than requested."
+          : null,
   };
+}
+
+function trackMatchesRequest(track: TrackDetail, trackId: string | null): boolean {
+  if (!trackId) return false;
+  const ids = new Set<string>([track.id]);
+  if (track.db_track_id) {
+    ids.add(track.db_track_id);
+    ids.add(`local:${track.db_track_id}`);
+  }
+  if (track.source_id) {
+    ids.add(track.source_id);
+    ids.add(`${track.source}:${track.source_id}`);
+  }
+  return ids.has(trackId);
 }


### PR DESCRIPTION
## Summary

This PR hardens the ingestion path and carries richer tracker metadata through to track detail views.

- Makes the Filen downloader write to temporary `.part` files, validates completed downloads by size/non-empty regular-file checks, and installs files without overwriting existing targets.
- Treats missing, empty, partial, or size-mismatched Filen helper outputs as failures before library ingestion, and clears stored paths for failed/skipped replay updates.
- Extracts featured artists, producers, and alternate titles from API tracker titles and extra fields, then applies producer/comment metadata as track composer/comments for API tracker and artist-grid ingests.
- Exposes composer and comments through backend track detail responses and the shared TypeScript API type.
- Updates the track info dialog to show primary artist, featured artists, producers, comments, and to refetch repeated requests with timeout and stale-response protection.
- Soft-deletes all tracks under a removed watched directory and avoids replacing existing album covers when tracker artwork is applied opportunistically.
- Refreshes the tracker API docs around auth, source keys, parse status/errors, era images, stats, and admin endpoints.

## Why

The current ingestion flow could treat incomplete helper output as successful and retain old file paths after failure states. Tracker-derived metadata also had useful producer/feature information that was either lost or only represented inconsistently. This change makes failed downloads harder to ingest accidentally and makes the richer metadata visible in the API and UI.

## Impact

Users should see more accurate track info for tracker-ingested songs, especially featured artists and producers. Filen downloads should no longer overwrite existing files or ingest partial output, and directory removals from watched roots should clean up all contained tracks. Existing album artwork is preserved when applying tracker-derived covers.

## Validation

- `git diff --check`
- `go test ./...` from `backend`
- `npm run typecheck` from `frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added composer and comments metadata fields to track details
  * Added request timeout handling for track information requests with refresh capability
  * Enhanced file download safety with validation and verification
  * Improved file system event handling with safer deletion tracking

* **Bug Fixes**
  * Fixed file path persistence logic to handle different download statuses correctly
  * Added track matching validation to prevent loading mismatched data

* **Documentation**
  * Updated API specification with new endpoints, error handling, and metadata fields

* **Tests**
  * Added unit tests for metadata extraction and file validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->