### PR TITLE
[codex] Add view album actions for local and TIDAL tracks

### DIFF
--- a/backend/internal/httpapi/handlers/playlists.go
+++ b/backend/internal/httpapi/handlers/playlists.go
@@ -206,22 +206,23 @@ type tracksResp struct {
 }
 
 type trackItem struct {
-	Position    int    `json:"position"`
-	TrackID     string `json:"track_id"`
-	DBTrackID   string `json:"db_track_id,omitempty"`
-	Source      string `json:"source,omitempty"`
-	SourceID    string `json:"source_id,omitempty"`
-	Title       string `json:"title"`
-	AlbumID     string `json:"album_id,omitempty"`
-	AlbumTitle  string `json:"album_title,omitempty"`
-	TrackNo     int    `json:"track_no,omitempty"`
-	DurationMS  int    `json:"duration_ms"`
-	Artist      string `json:"artist,omitempty"`
-	AddedByID   string `json:"added_by_id,omitempty"`
-	AddedByName string `json:"added_by,omitempty"`
-	AddedAt     string `json:"added_at"`
-	PlayCount   int    `json:"play_count"`
-	CoverURL    string `json:"cover_url,omitempty"`
+	Position      int    `json:"position"`
+	TrackID       string `json:"track_id"`
+	DBTrackID     string `json:"db_track_id,omitempty"`
+	Source        string `json:"source,omitempty"`
+	SourceID      string `json:"source_id,omitempty"`
+	SourceAlbumID string `json:"source_album_id,omitempty"`
+	Title         string `json:"title"`
+	AlbumID       string `json:"album_id,omitempty"`
+	AlbumTitle    string `json:"album_title,omitempty"`
+	TrackNo       int    `json:"track_no,omitempty"`
+	DurationMS    int    `json:"duration_ms"`
+	Artist        string `json:"artist,omitempty"`
+	AddedByID     string `json:"added_by_id,omitempty"`
+	AddedByName   string `json:"added_by,omitempty"`
+	AddedAt       string `json:"added_at"`
+	PlayCount     int    `json:"play_count"`
+	CoverURL      string `json:"cover_url,omitempty"`
 }
 
 func (h *Playlists) ListTracks(w http.ResponseWriter, r *http.Request) {
@@ -251,20 +252,21 @@ func (h *Playlists) ListTracks(w http.ResponseWriter, r *http.Request) {
 			sourceID = t.TrackID.String()
 		}
 		ti := trackItem{
-			Position:    t.Position,
-			TrackID:     canonicalTrackRef(source, t.TrackID, t.ExternalID),
-			DBTrackID:   t.TrackID.String(),
-			Source:      source,
-			SourceID:    sourceID,
-			Title:       t.Title,
-			AlbumTitle:  t.AlbumTitle,
-			TrackNo:     t.TrackNo,
-			DurationMS:  t.DurationMS,
-			Artist:      t.Artist,
-			AddedByName: t.AddedByName,
-			AddedAt:     t.AddedAt.Format("2006-01-02T15:04:05Z07:00"),
-			PlayCount:   t.PlayCount,
-			CoverURL:    t.CoverURL,
+			Position:      t.Position,
+			TrackID:       canonicalTrackRef(source, t.TrackID, t.ExternalID),
+			DBTrackID:     t.TrackID.String(),
+			Source:        source,
+			SourceID:      sourceID,
+			SourceAlbumID: t.ExternalAlbumID,
+			Title:         t.Title,
+			AlbumTitle:    t.AlbumTitle,
+			TrackNo:       t.TrackNo,
+			DurationMS:    t.DurationMS,
+			Artist:        t.Artist,
+			AddedByName:   t.AddedByName,
+			AddedAt:       t.AddedAt.Format("2006-01-02T15:04:05Z07:00"),
+			PlayCount:     t.PlayCount,
+			CoverURL:      t.CoverURL,
 		}
 		if t.AlbumID != nil {
 			ti.AlbumID = t.AlbumID.String()

--- a/backend/internal/httpapi/handlers/search.go
+++ b/backend/internal/httpapi/handlers/search.go
@@ -74,15 +74,16 @@ func (h *Search) Search(w http.ResponseWriter, r *http.Request) {
 			}
 			for _, it := range items {
 				resp.Tracks = append(resp.Tracks, trackListItemResp{
-					ID:         trackref.Remote(trackref.SourceTIDAL, it.ID),
-					Source:     trackref.SourceTIDAL,
-					SourceID:   it.ID,
-					Title:      it.Title,
-					AlbumTitle: it.AlbumTitle,
-					TrackNo:    it.TrackNo,
-					DurationMS: it.DurationMS,
-					Artist:     strings.Join(it.Artists, ", "),
-					CoverURL:   it.CoverURL,
+					ID:            trackref.Remote(trackref.SourceTIDAL, it.ID),
+					Source:        trackref.SourceTIDAL,
+					SourceID:      it.ID,
+					SourceAlbumID: it.AlbumID,
+					Title:         it.Title,
+					AlbumTitle:    it.AlbumTitle,
+					TrackNo:       it.TrackNo,
+					DurationMS:    it.DurationMS,
+					Artist:        strings.Join(it.Artists, ", "),
+					CoverURL:      it.CoverURL,
 				})
 			}
 		}

--- a/backend/internal/httpapi/handlers/tidal.go
+++ b/backend/internal/httpapi/handlers/tidal.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/githubesson/lumen/internal/tidal"
+	"github.com/githubesson/lumen/internal/trackref"
+)
+
+type TIDAL struct {
+	TIDAL *tidal.Client
+}
+
+type tidalAlbumResp struct {
+	ID          string              `json:"id"`
+	Title       string              `json:"title"`
+	Artist      string              `json:"artist,omitempty"`
+	ReleaseYear int                 `json:"release_year,omitempty"`
+	TrackCount  int                 `json:"track_count"`
+	DurationMS  int                 `json:"duration_ms"`
+	CoverURL    string              `json:"cover_url,omitempty"`
+	Tracks      []trackListItemResp `json:"tracks"`
+}
+
+func (h *TIDAL) Album(w http.ResponseWriter, r *http.Request) {
+	if _, ok := requireUser(w, r); !ok {
+		return
+	}
+	if h.TIDAL == nil {
+		http.Error(w, "tidal proxy is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	album, err := h.TIDAL.Album(r.Context(), chi.URLParam(r, "id"), limit, offset)
+	if err != nil {
+		if errors.Is(err, tidal.ErrNotConfigured) {
+			http.Error(w, "tidal proxy is not configured", http.StatusServiceUnavailable)
+			return
+		}
+		http.Error(w, "tidal album unavailable", http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, makeTIDALAlbumResp(album))
+}
+
+func makeTIDALAlbumResp(album tidal.Album) tidalAlbumResp {
+	out := tidalAlbumResp{
+		ID:          album.ID,
+		Title:       album.Title,
+		Artist:      album.Artist,
+		ReleaseYear: album.ReleaseYear,
+		TrackCount:  album.TrackCount,
+		DurationMS:  album.DurationMS,
+		CoverURL:    album.CoverURL,
+		Tracks:      make([]trackListItemResp, 0, len(album.Tracks)),
+	}
+	for _, it := range album.Tracks {
+		out.Tracks = append(out.Tracks, trackListItemResp{
+			ID:            trackref.Remote(trackref.SourceTIDAL, it.ID),
+			Source:        trackref.SourceTIDAL,
+			SourceID:      it.ID,
+			SourceAlbumID: it.AlbumID,
+			Title:         it.Title,
+			AlbumTitle:    firstNonEmpty(it.AlbumTitle, album.Title),
+			TrackNo:       it.TrackNo,
+			DurationMS:    it.DurationMS,
+			Artist:        strings.Join(it.Artists, ", "),
+			CoverURL:      firstNonEmpty(it.CoverURL, album.CoverURL),
+		})
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/backend/internal/httpapi/handlers/tracks.go
+++ b/backend/internal/httpapi/handlers/tracks.go
@@ -74,47 +74,49 @@ type trackArtistResp struct {
 }
 
 type trackDetailResp struct {
-	ID         string            `json:"id"`
-	DBTrackID  string            `json:"db_track_id,omitempty"`
-	Source     string            `json:"source"`
-	SourceID   string            `json:"source_id,omitempty"`
-	Title      string            `json:"title"`
-	AlbumID    string            `json:"album_id,omitempty"`
-	AlbumTitle string            `json:"album_title,omitempty"`
-	TrackNo    int               `json:"track_no,omitempty"`
-	DiscNo     int               `json:"disc_no,omitempty"`
-	DurationMS int               `json:"duration_ms"`
-	Genre      string            `json:"genre,omitempty"`
-	Year       int               `json:"year,omitempty"`
-	Composer   string            `json:"composer,omitempty"`
-	Comments   string            `json:"comments,omitempty"`
-	Format     string            `json:"format"`
-	Bitrate    int               `json:"bitrate,omitempty"`
-	SampleRate int               `json:"sample_rate,omitempty"`
-	Channels   int               `json:"channels,omitempty"`
-	FileSize   int64             `json:"file_size"`
-	Artists    []trackArtistResp `json:"artists"`
-	Aliases    []trackAliasResp  `json:"aliases,omitempty"`
-	HasCover   bool              `json:"has_cover"`
-	CoverURL   string            `json:"cover_url,omitempty"`
-	Favorited  bool              `json:"favorited"`
+	ID            string            `json:"id"`
+	DBTrackID     string            `json:"db_track_id,omitempty"`
+	Source        string            `json:"source"`
+	SourceID      string            `json:"source_id,omitempty"`
+	SourceAlbumID string            `json:"source_album_id,omitempty"`
+	Title         string            `json:"title"`
+	AlbumID       string            `json:"album_id,omitempty"`
+	AlbumTitle    string            `json:"album_title,omitempty"`
+	TrackNo       int               `json:"track_no,omitempty"`
+	DiscNo        int               `json:"disc_no,omitempty"`
+	DurationMS    int               `json:"duration_ms"`
+	Genre         string            `json:"genre,omitempty"`
+	Year          int               `json:"year,omitempty"`
+	Composer      string            `json:"composer,omitempty"`
+	Comments      string            `json:"comments,omitempty"`
+	Format        string            `json:"format"`
+	Bitrate       int               `json:"bitrate,omitempty"`
+	SampleRate    int               `json:"sample_rate,omitempty"`
+	Channels      int               `json:"channels,omitempty"`
+	FileSize      int64             `json:"file_size"`
+	Artists       []trackArtistResp `json:"artists"`
+	Aliases       []trackAliasResp  `json:"aliases,omitempty"`
+	HasCover      bool              `json:"has_cover"`
+	CoverURL      string            `json:"cover_url,omitempty"`
+	Favorited     bool              `json:"favorited"`
 }
 
 type trackListItemResp struct {
-	ID         string `json:"id"`
-	DBTrackID  string `json:"db_track_id,omitempty"`
-	Source     string `json:"source,omitempty"`
-	SourceID   string `json:"source_id,omitempty"`
-	Title      string `json:"title"`
-	AlbumID    string `json:"album_id,omitempty"`
-	AlbumTitle string `json:"album_title,omitempty"`
-	TrackNo    int    `json:"track_no,omitempty"`
-	DurationMS int    `json:"duration_ms"`
-	Artist     string `json:"artist,omitempty"`
-	Aka        string `json:"aka,omitempty"` // " • "-joined alt titles from dedup'd copies
-	Favorited  bool   `json:"favorited,omitempty"`
-	Owned      bool   `json:"owned,omitempty"` // true = the viewer's own personal upload (deletable)
-	CoverURL   string `json:"cover_url,omitempty"`
+	ID            string `json:"id"`
+	DBTrackID     string `json:"db_track_id,omitempty"`
+	Source        string `json:"source,omitempty"`
+	SourceID      string `json:"source_id,omitempty"`
+	SourceAlbumID string `json:"source_album_id,omitempty"`
+	Title         string `json:"title"`
+	AlbumID       string `json:"album_id,omitempty"`
+	AlbumTitle    string `json:"album_title,omitempty"`
+	TrackNo       int    `json:"track_no,omitempty"`
+	DurationMS    int    `json:"duration_ms"`
+	Artist        string `json:"artist,omitempty"`
+	Aka           string `json:"aka,omitempty"` // " • "-joined alt titles from dedup'd copies
+	Favorited     bool   `json:"favorited,omitempty"`
+	Owned         bool   `json:"owned,omitempty"` // true = the viewer's own personal upload (deletable)
+	CoverURL      string `json:"cover_url,omitempty"`
 }
 
 type trackAliasResp struct {
@@ -318,28 +320,29 @@ func makeTrackDetailResp(t *library.TrackDetail, isFav bool) trackDetailResp {
 		sourceID = t.ID.String()
 	}
 	resp := trackDetailResp{
-		ID:         id,
-		DBTrackID:  t.ID.String(),
-		Source:     source,
-		SourceID:   sourceID,
-		Title:      t.Title,
-		AlbumTitle: t.AlbumTitle,
-		TrackNo:    t.TrackNo,
-		DiscNo:     t.DiscNo,
-		DurationMS: t.DurationMS,
-		Genre:      t.Genre,
-		Year:       t.Year,
-		Composer:   t.Composer,
-		Comments:   t.Comments,
-		Format:     t.Format,
-		Bitrate:    t.Bitrate,
-		SampleRate: t.SampleRate,
-		Channels:   t.Channels,
-		FileSize:   t.FileSize,
-		HasCover:   t.CoverArtPath != "" || t.CoverURL != "",
-		CoverURL:   t.CoverURL,
-		Favorited:  isFav,
-		Artists:    make([]trackArtistResp, 0, len(t.Artists)),
+		ID:            id,
+		DBTrackID:     t.ID.String(),
+		Source:        source,
+		SourceID:      sourceID,
+		SourceAlbumID: t.ExternalAlbumID,
+		Title:         t.Title,
+		AlbumTitle:    t.AlbumTitle,
+		TrackNo:       t.TrackNo,
+		DiscNo:        t.DiscNo,
+		DurationMS:    t.DurationMS,
+		Genre:         t.Genre,
+		Year:          t.Year,
+		Composer:      t.Composer,
+		Comments:      t.Comments,
+		Format:        t.Format,
+		Bitrate:       t.Bitrate,
+		SampleRate:    t.SampleRate,
+		Channels:      t.Channels,
+		FileSize:      t.FileSize,
+		HasCover:      t.CoverArtPath != "" || t.CoverURL != "",
+		CoverURL:      t.CoverURL,
+		Favorited:     isFav,
+		Artists:       make([]trackArtistResp, 0, len(t.Artists)),
 	}
 	if t.AlbumID != nil {
 		resp.AlbumID = t.AlbumID.String()

--- a/backend/internal/httpapi/router.go
+++ b/backend/internal/httpapi/router.go
@@ -71,6 +71,7 @@ func NewRouter(d Deps) http.Handler {
 	libH := &handlers.Library{Ingest: d.Ingest, Library: d.Library}
 	plH := &handlers.Playlists{Store: d.Playlists, Users: d.Users, Library: d.Library, TIDAL: d.TIDAL}
 	searchH := &handlers.Search{Library: d.Library, TIDAL: d.TIDAL}
+	tidalH := &handlers.TIDAL{TIDAL: d.TIDAL}
 	adminUsersH := &handlers.AdminUsers{DB: d.DB, Users: d.Users, Playlists: d.Playlists}
 	adminRootsH := &handlers.AdminRoots{
 		Store:       d.MusicRoots,
@@ -163,6 +164,7 @@ func NewRouter(d Deps) http.Handler {
 
 			r.Get("/tracks", tracksH.List)
 			r.Get("/search", searchH.Search)
+			r.Get("/tidal/albums/{id}", tidalH.Album)
 			r.Get("/tracks/{id}", tracksH.Get)
 			r.Delete("/tracks/{id}", tracksH.Delete)
 			r.Get("/tracks/{id}/stream", tracksH.Stream)

--- a/backend/internal/library/read.go
+++ b/backend/internal/library/read.go
@@ -10,30 +10,31 @@ import (
 )
 
 type TrackDetail struct {
-	ID           uuid.UUID
-	Title        string
-	AlbumID      *uuid.UUID
-	AlbumTitle   string
-	TrackNo      int
-	DiscNo       int
-	DurationMS   int
-	Genre        string
-	Year         int
-	Composer     string
-	Comments     string
-	Format       string
-	Bitrate      int
-	SampleRate   int
-	Channels     int
-	FilePath     string
-	FileSize     int64
-	Source       string
-	ExternalID   string
-	CoverURL     string
-	Artists      []TrackArtist
-	Aliases      []TrackAlias
-	CoverArtPath string
-	CreatedAt    time.Time
+	ID              uuid.UUID
+	Title           string
+	AlbumID         *uuid.UUID
+	AlbumTitle      string
+	TrackNo         int
+	DiscNo          int
+	DurationMS      int
+	Genre           string
+	Year            int
+	Composer        string
+	Comments        string
+	Format          string
+	Bitrate         int
+	SampleRate      int
+	Channels        int
+	FilePath        string
+	FileSize        int64
+	Source          string
+	ExternalID      string
+	ExternalAlbumID string
+	CoverURL        string
+	Artists         []TrackArtist
+	Aliases         []TrackAlias
+	CoverArtPath    string
+	CreatedAt       time.Time
 }
 
 type TrackArtist struct {
@@ -66,7 +67,8 @@ const trackDetailSelect = `
 		t.format,
 		COALESCE(t.bitrate, 0), COALESCE(t.sample_rate, 0), COALESCE(t.channels, 0),
 		t.file_path, t.file_size,
-		t.source, t.external_id, COALESCE(t.external_meta->>'cover_url', ''),
+		t.source, t.external_id, COALESCE(t.external_meta->>'album_id', ''),
+		COALESCE(t.external_meta->>'cover_url', ''),
 		t.created_at
 	FROM tracks t
 	LEFT JOIN albums a ON a.id = t.album_id
@@ -105,7 +107,7 @@ func (s *Store) getTrackDetail(ctx context.Context, query string, args ...any) (
 		&t.Format,
 		&t.Bitrate, &t.SampleRate, &t.Channels,
 		&t.FilePath, &t.FileSize,
-		&t.Source, &t.ExternalID, &t.CoverURL,
+		&t.Source, &t.ExternalID, &t.ExternalAlbumID, &t.CoverURL,
 		&t.CreatedAt,
 	)
 	if err != nil {

--- a/backend/internal/playlists/store.go
+++ b/backend/internal/playlists/store.go
@@ -172,21 +172,22 @@ func (s *Store) Tracks(ctx context.Context, id uuid.UUID) ([]TrackEntry, error) 
 // TrackDetail is a playlist entry joined with track + artist + album data so
 // the UI can render a full row in one query.
 type TrackDetail struct {
-	Position    int
-	TrackID     uuid.UUID
-	Title       string
-	AlbumID     *uuid.UUID
-	AlbumTitle  string
-	TrackNo     int
-	DurationMS  int
-	Artist      string // primary artists joined with ", "
-	Source      string
-	ExternalID  string
-	CoverURL    string
-	AddedBy     *uuid.UUID
-	AddedByName string
-	AddedAt     time.Time
-	PlayCount   int // viewer's all-time plays of this track
+	Position        int
+	TrackID         uuid.UUID
+	Title           string
+	AlbumID         *uuid.UUID
+	AlbumTitle      string
+	TrackNo         int
+	DurationMS      int
+	Artist          string // primary artists joined with ", "
+	Source          string
+	ExternalID      string
+	ExternalAlbumID string
+	CoverURL        string
+	AddedBy         *uuid.UUID
+	AddedByName     string
+	AddedAt         time.Time
+	PlayCount       int // viewer's all-time plays of this track
 }
 
 // TracksDetailed returns all tracks in a playlist visible to viewerID (global
@@ -205,6 +206,7 @@ func (s *Store) TracksDetailed(ctx context.Context, id, viewerID uuid.UUID) ([]T
 				''),
 			t.source,
 			t.external_id,
+			COALESCE(t.external_meta->>'album_id', ''),
 			COALESCE(t.external_meta->>'cover_url', ''),
 			pt.added_by,
 			COALESCE(u.username, ''),
@@ -230,7 +232,7 @@ func (s *Store) TracksDetailed(ctx context.Context, id, viewerID uuid.UUID) ([]T
 		if err := rows.Scan(
 			&td.Position, &td.TrackID, &td.Title, &td.AlbumID, &td.AlbumTitle,
 			&td.TrackNo, &td.DurationMS, &td.Artist,
-			&td.Source, &td.ExternalID, &td.CoverURL,
+			&td.Source, &td.ExternalID, &td.ExternalAlbumID, &td.CoverURL,
 			&td.AddedBy, &td.AddedByName, &td.AddedAt, &td.PlayCount,
 		); err != nil {
 			return nil, err

--- a/backend/internal/tidal/client.go
+++ b/backend/internal/tidal/client.go
@@ -109,6 +109,18 @@ type Track struct {
 	CoverURL    string
 }
 
+type Album struct {
+	ID          string
+	Title       string
+	Artist      string
+	ReleaseYear int
+	TrackCount  int
+	DurationMS  int
+	CoverID     string
+	CoverURL    string
+	Tracks      []Track
+}
+
 func (t Track) Metadata() map[string]any {
 	return map[string]any{
 		"album_id":     t.AlbumID,
@@ -157,6 +169,42 @@ func (c *Client) SearchTracks(ctx context.Context, query string, limit, offset i
 	}
 	slog.Debug("tidal hifi search response", "query", query, "count", len(tracks), "version", out.Version)
 	return tracks, nil
+}
+
+func (c *Client) Album(ctx context.Context, id string, limit, offset int) (Album, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return Album{}, errors.New("tidal album id is required")
+	}
+	if strings.TrimSpace(c.cfg.HifiAPIURL) == "" {
+		return Album{}, ErrNotConfigured
+	}
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	u := c.hifiURL("/album/")
+	q := u.Query()
+	q.Set("id", id)
+	q.Set("limit", strconv.Itoa(limit))
+	q.Set("offset", strconv.Itoa(offset))
+	u.RawQuery = q.Encode()
+	var out struct {
+		Version string   `json:"version"`
+		Data    apiAlbum `json:"data"`
+	}
+	slog.Debug("tidal hifi album request", "album", id, "limit", limit, "offset", offset, "url", logSafeURL(u.String()))
+	if err := c.doHifiJSON(ctx, u.String(), &out); err != nil {
+		return Album{}, err
+	}
+	album := out.Data.album()
+	if album.ID == "" {
+		return Album{}, errors.New("hifi-api album response did not include an album")
+	}
+	slog.Debug("tidal hifi album response", "album", id, "title", album.Title, "tracks", len(album.Tracks), "version", out.Version)
+	return album, nil
 }
 
 func (c *Client) Track(ctx context.Context, id string) (Track, error) {
@@ -715,11 +763,15 @@ type apiArtist struct {
 }
 
 type apiAlbum struct {
-	ID          tidalID   `json:"id"`
-	Title       string    `json:"title"`
-	Cover       string    `json:"cover"`
-	ReleaseDate string    `json:"releaseDate"`
-	Artist      apiArtist `json:"artist"`
+	ID             tidalID        `json:"id"`
+	Title          string         `json:"title"`
+	Cover          string         `json:"cover"`
+	ReleaseDate    string         `json:"releaseDate"`
+	Duration       int            `json:"duration"`
+	NumberOfTracks int            `json:"numberOfTracks"`
+	Artist         apiArtist      `json:"artist"`
+	Artists        []apiArtist    `json:"artists"`
+	Items          []apiAlbumItem `json:"items"`
 }
 
 type apiTrack struct {
@@ -732,6 +784,61 @@ type apiTrack struct {
 	Artist       apiArtist   `json:"artist"`
 	Artists      []apiArtist `json:"artists"`
 	Album        apiAlbum    `json:"album"`
+}
+
+type apiAlbumItem struct {
+	Item apiTrack `json:"item"`
+	Type string   `json:"type"`
+}
+
+func (a apiAlbum) album() Album {
+	year := 0
+	if len(a.ReleaseDate) >= 4 {
+		year, _ = strconv.Atoi(a.ReleaseDate[:4])
+	}
+	artist := strings.TrimSpace(a.Artist.Name)
+	if artist == "" && len(a.Artists) > 0 {
+		artist = strings.TrimSpace(a.Artists[0].Name)
+	}
+	coverID := strings.TrimSpace(a.Cover)
+	album := Album{
+		ID:          string(a.ID),
+		Title:       a.Title,
+		Artist:      artist,
+		ReleaseYear: year,
+		TrackCount:  a.NumberOfTracks,
+		DurationMS:  max(0, a.Duration) * 1000,
+		CoverID:     coverID,
+		CoverURL:    CoverURL(coverID, 640),
+		Tracks:      make([]Track, 0, len(a.Items)),
+	}
+	for _, item := range a.Items {
+		if item.Type != "" && !strings.EqualFold(item.Type, "track") {
+			continue
+		}
+		track := item.Item.track()
+		if track.ID == "" || track.Title == "" {
+			continue
+		}
+		if track.AlbumID == "" {
+			track.AlbumID = album.ID
+		}
+		if track.AlbumTitle == "" {
+			track.AlbumTitle = album.Title
+		}
+		if track.AlbumArtist == "" {
+			track.AlbumArtist = album.Artist
+		}
+		if track.CoverID == "" {
+			track.CoverID = album.CoverID
+			track.CoverURL = album.CoverURL
+		}
+		album.Tracks = append(album.Tracks, track)
+	}
+	if album.TrackCount == 0 {
+		album.TrackCount = len(album.Tracks)
+	}
+	return album
 }
 
 func (t apiTrack) track() Track {

--- a/backend/internal/tidal/client_test.go
+++ b/backend/internal/tidal/client_test.go
@@ -180,6 +180,35 @@ func TestHifiSearchTracks(t *testing.T) {
 	}
 }
 
+func TestHifiAlbum(t *testing.T) {
+	var gotID, gotLimit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/album/" {
+			t.Fatalf("path = %q, want /album/", r.URL.Path)
+		}
+		gotID = r.URL.Query().Get("id")
+		gotLimit = r.URL.Query().Get("limit")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"2.10","data":{"id":58990510,"title":"OK Computer","duration":3216,"numberOfTracks":12,"releaseDate":"1997-07-01","cover":"e77e4cc0-6cd0-4522-807d-88aeac488065","artist":{"name":"Radiohead"},"items":[{"type":"track","item":{"id":58990511,"title":"Airbag","duration":287,"trackNumber":1,"volumeNumber":1,"artist":{"name":"Radiohead"},"artists":[{"name":"Radiohead"}],"album":{"id":58990510,"title":"OK Computer","cover":"e77e4cc0-6cd0-4522-807d-88aeac488065"}}}]}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{HifiAPIURL: srv.URL})
+	album, err := c.Album(context.Background(), "58990510", 100, 0)
+	if err != nil {
+		t.Fatalf("Album returned error: %v", err)
+	}
+	if gotID != "58990510" || gotLimit != "100" {
+		t.Fatalf("query id=%q limit=%q, want id=58990510 limit=100", gotID, gotLimit)
+	}
+	if album.ID != "58990510" || album.Title != "OK Computer" || album.Artist != "Radiohead" {
+		t.Fatalf("unexpected album: %+v", album)
+	}
+	if len(album.Tracks) != 1 || album.Tracks[0].ID != "58990511" || album.Tracks[0].AlbumID != "58990510" {
+		t.Fatalf("unexpected album tracks: %+v", album.Tracks)
+	}
+}
+
 func TestHifiStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {

--- a/core/src/api.ts
+++ b/core/src/api.ts
@@ -416,6 +416,8 @@ export const api = {
     request<Album>(`/api/albums/${id}`, options),
   listAlbumTracks: (id: string, options: RequestOptions = {}) =>
     request<TrackListItem[]>(`/api/albums/${id}/tracks`, options),
+  getTidalAlbum: (id: string, options: RequestOptions = {}) =>
+    request<TidalAlbum>(`/api/tidal/albums/${encodeURIComponent(id)}`, options),
 
   listArtistsPage: (params: PageParams = {}) =>
     fetchPage<Artist>("/api/artists", params),
@@ -588,6 +590,7 @@ export interface TrackListItem {
   db_track_id?: string;
   source?: TrackSource;
   source_id?: string;
+  source_album_id?: string;
   title: string;
   album_id?: string;
   album_title?: string;
@@ -627,6 +630,7 @@ export interface TrackDetail {
   db_track_id?: string;
   source: TrackSource;
   source_id?: string;
+  source_album_id?: string;
   title: string;
   album_id?: string;
   album_title?: string;
@@ -672,6 +676,7 @@ export interface PlaylistTrackEntry {
   db_track_id?: string;
   source?: TrackSource;
   source_id?: string;
+  source_album_id?: string;
   title: string;
   album_id?: string;
   album_title?: string;
@@ -699,6 +704,17 @@ export interface TidalStatus {
   version?: string;
   repo?: string;
   error?: string;
+}
+
+export interface TidalAlbum {
+  id: string;
+  title: string;
+  artist?: string;
+  release_year?: number;
+  track_count: number;
+  duration_ms: number;
+  cover_url?: string;
+  tracks: TrackListItem[];
 }
 
 export interface Collaborator {
@@ -1210,6 +1226,7 @@ export function toQueueItem(entry: PlaylistTrackEntry): TrackListItem {
     artist: entry.artist,
     source: entry.source,
     source_id: entry.source_id,
+    source_album_id: entry.source_album_id,
     cover_url: entry.cover_url,
   };
 }

--- a/frontend/src/components/TrackContextMenu.tsx
+++ b/frontend/src/components/TrackContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
 import {
   ArrowDownTrayIcon,
   CheckIcon,
@@ -76,6 +77,7 @@ export default function TrackContextMenu({
   onClose,
 }: Props) {
   const { play } = usePlayer();
+  const navigate = useNavigate();
   const { isFavorite, toggle: toggleFav } = useFavorites();
   const { me } = useAuth();
   const isAdmin = me?.role === "admin";
@@ -89,6 +91,7 @@ export default function TrackContextMenu({
   const [addingId, setAddingId] = useState<string | null>(null);
   const [addedIds, setAddedIds] = useState<Set<string>>(new Set());
   const [downloading, setDownloading] = useState(false);
+  const [viewingAlbum, setViewingAlbum] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -195,6 +198,39 @@ export default function TrackContextMenu({
     onClose();
   };
 
+  const runViewAlbum = async () => {
+    if (viewingAlbum) return;
+    setViewingAlbum(true);
+    setError(null);
+    try {
+      let localAlbumID = track.album_id;
+      let tidalAlbumID =
+        track.source === "tidal" ? track.source_album_id : undefined;
+      if (!localAlbumID || (track.source === "tidal" && !tidalAlbumID)) {
+        const detail = await api.getTrack(track.id);
+        localAlbumID = localAlbumID || detail.album_id;
+        if (detail.source === "tidal") {
+          tidalAlbumID = tidalAlbumID || detail.source_album_id;
+        }
+      }
+      if (track.source === "tidal" && tidalAlbumID) {
+        navigate(`/library?view=albums&tidalAlbum=${encodeURIComponent(tidalAlbumID)}`);
+        onClose();
+        return;
+      }
+      if (localAlbumID) {
+        navigate(`/library?view=albums&album=${encodeURIComponent(localAlbumID)}`);
+        onClose();
+        return;
+      }
+      setError("No album found for this track.");
+      setViewingAlbum(false);
+    } catch (err) {
+      setError(errorMessage(err, "Album lookup failed."));
+      setViewingAlbum(false);
+    }
+  };
+
   const runShare = () => {
     onShare?.();
     onClose();
@@ -281,6 +317,18 @@ export default function TrackContextMenu({
         >
           <InformationCircleIcon className="size-3.5" />
           <span>Song info</span>
+        </button>
+      )}
+      {(track.album_id || track.album_title || track.source === "tidal") && (
+        <button
+          type="button"
+          role="menuitem"
+          className="ctx-item"
+          onClick={() => void runViewAlbum()}
+          disabled={viewingAlbum}
+        >
+          <RectangleStackIcon className="size-3.5" />
+          <span>{viewingAlbum ? "Opening album..." : "View album"}</span>
         </button>
       )}
       {onShare && (

--- a/frontend/src/pages/Library.tsx
+++ b/frontend/src/pages/Library.tsx
@@ -28,7 +28,11 @@ import { useTrackContextMenu } from "../components/TrackContextMenu";
 import { usePlayer } from "../context/Player";
 import { usePaginatedList } from "../lib/usePaginatedList";
 import GridView from "./library/GridView";
-import { AlbumDetailView, ArtistDetailView } from "./library/LibraryDetail";
+import {
+  AlbumDetailView,
+  ArtistDetailView,
+  TidalAlbumDetailView,
+} from "./library/LibraryDetail";
 
 const POLL_INTERVAL_MS = 15 * 60 * 1000;
 
@@ -53,6 +57,7 @@ export default function Library() {
     ? (params.get("view") as View)
     : "tracks";
   const albumID = params.get("album");
+  const tidalAlbumID = params.get("tidalAlbum");
   const artistID = params.get("artist");
   const query = params.get("q") ?? "";
 
@@ -94,6 +99,15 @@ export default function Library() {
 
   if (albumID) {
     return <AlbumDetailView key={albumID} id={albumID} onBack={clearDrill} />;
+  }
+  if (tidalAlbumID) {
+    return (
+      <TidalAlbumDetailView
+        key={tidalAlbumID}
+        id={tidalAlbumID}
+        onBack={clearDrill}
+      />
+    );
   }
   if (artistID) {
     return <ArtistDetailView key={artistID} id={artistID} onBack={clearDrill} />;

--- a/frontend/src/pages/library/LibraryDetail.tsx
+++ b/frontend/src/pages/library/LibraryDetail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
   ArrowLeftIcon,
   PencilSquareIcon,
@@ -7,9 +7,11 @@ import {
 import {
   api,
   albumCoverUrl,
+  errorMessage,
   trackCoverUrl,
   type Album,
   type Artist,
+  type TidalAlbum,
   type TrackListItem,
 } from "../../api";
 import { displayText, pluralize } from "../../lib/format";
@@ -151,6 +153,133 @@ export function AlbumDetailView({
           setCoverNonce(Date.now());
         }}
       />
+    </div>
+  );
+}
+
+export function TidalAlbumDetailView({
+  id,
+  onBack,
+}: {
+  id: string;
+  onBack: () => void;
+}) {
+  const [album, setAlbum] = useState<TidalAlbum | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { play } = usePlayer();
+  const search = useDetailTrackSearch("album", album?.tracks ?? null);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    setAlbum(null);
+    setError(null);
+    api
+      .getTidalAlbum(id, { signal: ac.signal })
+      .then((next) => {
+        if (!ac.signal.aborted) setAlbum(next);
+      })
+      .catch((err) => {
+        if (!ac.signal.aborted) {
+          setError(errorMessage(err, "Failed to load TIDAL album."));
+        }
+      });
+    return () => ac.abort();
+  }, [id]);
+
+  if (!album && !error) {
+    return (
+      <div className="view">
+        <LoadingState label="Loading TIDAL album..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="view" style={{ display: "grid", gap: 18 }}>
+      <DetailBackRow onBack={onBack} />
+      {album ? (
+        <>
+          <ListPageHeader
+            kind="TIDAL Album"
+            title={displayText(album.title)}
+            art={
+              <CoverArt
+                className="detail-art"
+                src={album.cover_url ?? null}
+                seed={`tidal:${album.id}`}
+                label={album.title}
+                forcePlaceholder={!album.cover_url}
+              />
+            }
+            meta={
+              <>
+                {album.artist && (
+                  <>
+                    <span>{displayText(album.artist)}</span>
+                    <span className="dot" />
+                  </>
+                )}
+                <span>{pluralize(album.track_count, "track")}</span>
+                {album.release_year ? (
+                  <>
+                    <span className="dot" />
+                    <span>{album.release_year}</span>
+                  </>
+                ) : null}
+              </>
+            }
+            actions={
+              <Button
+                variant="primary"
+                onClick={() => album.tracks.length && play(album.tracks[0], album.tracks)}
+                disabled={album.tracks.length === 0}
+                leadingIcon={<PlayIcon className="size-4" />}
+              >
+                Play all
+              </Button>
+            }
+            corner={
+              <DetailTrackSearchBar
+                kind="album"
+                query={search.query}
+                onQueryChange={search.setQuery}
+                inputRef={search.inputRef}
+                matchCount={search.filteredTracks.length}
+                totalCount={album.tracks.length}
+                searchActive={search.searchActive}
+              />
+            }
+          />
+          {error && <ErrorBanner message={error} />}
+          <TrackList
+            tracks={search.filteredTracks}
+            queueSource={album.tracks}
+            showAlbum={false}
+            emptyState={
+              search.searchActive ? (
+                <EmptyState
+                  title="No matches."
+                  hint={`Nothing in this album matches "${search.query}".`}
+                />
+              ) : undefined
+            }
+          />
+        </>
+      ) : (
+        <div
+          style={{
+            padding: 40,
+            textAlign: "center",
+            color: "var(--fg-muted)",
+            fontSize: 13,
+          }}
+        >
+          {error && <ErrorBanner message={error} />}
+          <p style={{ color: "var(--fg)", fontWeight: 500, fontSize: 14 }}>
+            TIDAL album unavailable.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/mobile/app/(tabs)/(library)/_layout.tsx
+++ b/mobile/app/(tabs)/(library)/_layout.tsx
@@ -11,6 +11,10 @@ export default function LibraryStackLayout() {
         options={{ headerLargeTitle: false, title: "" }}
       />
       <Stack.Screen
+        name="tidal-albums/[id]"
+        options={{ headerLargeTitle: false, title: "" }}
+      />
+      <Stack.Screen
         name="artists/[id]"
         options={{ headerLargeTitle: false, title: "" }}
       />

--- a/mobile/app/(tabs)/(library)/tidal-albums/[id].tsx
+++ b/mobile/app/(tabs)/(library)/tidal-albums/[id].tsx
@@ -1,0 +1,209 @@
+import { useCallback, useMemo } from "react";
+import {
+  ActivityIndicator,
+  PixelRatio,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { FlashList, type ListRenderItemInfo } from "@shopify/flash-list";
+import { useQuery } from "@tanstack/react-query";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { Image } from "expo-image";
+import { SymbolView } from "expo-symbols";
+import * as Haptics from "expo-haptics";
+import {
+  api,
+  useAuth,
+  type TrackListItem,
+} from "@music-library/core";
+import { TRACK_FLASH_LIST_PERFORMANCE_PROPS } from "../../../../components/list-performance";
+import {
+  useBottomDockInset,
+  useDockScrollHandler,
+} from "../../../../components/dock/dock-context";
+import { TrackRow } from "../../../../components/track-row";
+import { qk } from "../../../../lib/query-keys";
+import { usePlayQueue } from "../../../../lib/use-play-queue";
+import { useTheme } from "../../../../theme/theme";
+
+const ALBUM_ART_SIZE = 220;
+
+export default function TidalAlbumDetailScreen() {
+  const theme = useTheme();
+  const dockInset = useBottomDockInset();
+  const dockScroll = useDockScrollHandler();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { me } = useAuth();
+  const userId = me?.id;
+
+  const albumQuery = useQuery({
+    queryKey: qk.tidalAlbum(userId, id),
+    queryFn: ({ signal }) => api.getTidalAlbum(id!, { signal }),
+    enabled: !!userId && !!id,
+  });
+
+  const tracks = useMemo<TrackListItem[]>(
+    () => albumQuery.data?.tracks ?? [],
+    [albumQuery.data?.tracks],
+  );
+  const onTrackPress = usePlayQueue(tracks);
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<TrackListItem>) => (
+      <TrackRow track={item} onPress={onTrackPress} />
+    ),
+    [onTrackPress],
+  );
+
+  const keyExtractor = useCallback((track: TrackListItem) => track.id, []);
+
+  const header = useMemo(() => {
+    const album = albumQuery.data;
+    if (!album) return null;
+    const requestSize = Math.max(
+      1,
+      Math.round(ALBUM_ART_SIZE * PixelRatio.get()),
+    );
+    const coverUri = album.cover_url || null;
+    return (
+      <View
+        style={{
+          paddingHorizontal: theme.space.lg,
+          paddingBottom: theme.space.md,
+        }}
+      >
+        <View
+          style={{
+            alignItems: "center",
+            paddingVertical: theme.space.xl,
+            gap: theme.space.md,
+          }}
+        >
+          <View
+            style={{
+              width: ALBUM_ART_SIZE,
+              height: ALBUM_ART_SIZE,
+              borderRadius: theme.radius.lg,
+              overflow: "hidden",
+              borderCurve: "continuous",
+              backgroundColor: theme.color.bgElev2,
+            }}
+          >
+            {coverUri ? (
+              <Image
+                source={{ uri: coverUri }}
+                style={{ width: ALBUM_ART_SIZE, height: ALBUM_ART_SIZE }}
+                contentFit="cover"
+                transition={120}
+                cachePolicy="memory-disk"
+                allowDownscaling
+                decodeFormat="rgb"
+                recyclingKey={`${album.id}:${requestSize}`}
+              />
+            ) : null}
+          </View>
+          <View style={{ alignItems: "center", gap: 2 }}>
+            <Text
+              style={{
+                fontSize: 22,
+                fontWeight: "700",
+                color: theme.color.fg,
+                letterSpacing: -0.2,
+                textAlign: "center",
+              }}
+              numberOfLines={2}
+            >
+              {album.title}
+            </Text>
+            {album.artist ? (
+              <Text
+                style={{ fontSize: 16, color: theme.color.fgMuted }}
+                numberOfLines={1}
+              >
+                {album.artist}
+              </Text>
+            ) : null}
+            <Text style={{ fontSize: 13, color: theme.color.fgMuted, marginTop: 4 }}>
+              {album.track_count} {album.track_count === 1 ? "track" : "tracks"}
+              {album.release_year ? ` - ${album.release_year}` : ""}
+            </Text>
+          </View>
+        </View>
+        {tracks.length > 0 ? (
+          <Pressable
+            onPress={() => {
+              void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+              onTrackPress(tracks[0]);
+            }}
+            style={({ pressed }) => ({
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+              backgroundColor: theme.color.accent,
+              borderRadius: theme.radius.md,
+              paddingVertical: 12,
+              opacity: pressed ? 0.85 : 1,
+              borderCurve: "continuous",
+            })}
+          >
+            <SymbolView name="play.fill" size={14} tintColor={theme.color.onAccent} />
+            <Text style={{ color: theme.color.onAccent, fontWeight: "600", fontSize: 15 }}>
+              Play
+            </Text>
+          </Pressable>
+        ) : null}
+      </View>
+    );
+  }, [albumQuery.data, onTrackPress, tracks, theme]);
+
+  if (albumQuery.isLoading) {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.color.bg }]}>
+        <ActivityIndicator color={theme.color.fgMuted} />
+      </View>
+    );
+  }
+
+  if (albumQuery.isError || !albumQuery.data) {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.color.bg }]}>
+        <Text style={{ color: theme.color.fgMuted }}>
+          Couldn&apos;t load TIDAL album.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: albumQuery.data.title,
+          headerLargeTitle: false,
+        }}
+      />
+      <FlashList
+        {...TRACK_FLASH_LIST_PERFORMANCE_PROPS}
+        {...dockScroll}
+        data={tracks}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        ListHeaderComponent={header}
+        contentInsetAdjustmentBehavior="automatic"
+        style={{ backgroundColor: theme.color.bg }}
+        contentContainerStyle={{ paddingBottom: dockInset + 24 }}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/mobile/app/(tabs)/(playlists)/[id].tsx
+++ b/mobile/app/(tabs)/(playlists)/[id].tsx
@@ -831,6 +831,10 @@ function entryToTrack(e: PlaylistTrackEntry): TrackListItem {
     duration_ms: e.duration_ms,
     artist: e.artist,
     has_cover: e.has_cover,
+    cover_url: e.cover_url,
+    source: e.source,
+    source_id: e.source_id,
+    source_album_id: e.source_album_id,
   };
 }
 

--- a/mobile/app/share-track.tsx
+++ b/mobile/app/share-track.tsx
@@ -472,7 +472,11 @@ export default function ShareTrackScreen() {
     <>
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        style={{ flex: 1, backgroundColor: theme.color.bg }}
+        bounces={false}
+        alwaysBounceVertical={false}
+        alwaysBounceHorizontal={false}
+        overScrollMode="never"
+        style={[styles.noDragPage, { flex: 1, backgroundColor: theme.color.bg }]}
         contentContainerStyle={{
           paddingHorizontal: theme.space.lg,
           paddingTop: theme.space.lg,
@@ -486,7 +490,7 @@ export default function ShareTrackScreen() {
           </View>
         ) : trackQuery.isError || !trackQuery.data ? (
           <View style={styles.center}>
-            <Text selectable style={{ color: theme.color.fgMuted }}>
+            <Text style={{ color: theme.color.fgMuted }}>
               Couldn&apos;t load track.
             </Text>
           </View>
@@ -508,7 +512,6 @@ export default function ShareTrackScreen() {
             >
               <View style={styles.panelHeader}>
                 <Text
-                  selectable
                   style={{
                     color: theme.color.fg,
                     fontSize: 17,
@@ -572,7 +575,7 @@ export default function ShareTrackScreen() {
                 </Text>
               </Pressable>
 
-              <Text selectable style={{ color: theme.color.fgMuted }}>
+              <Text style={{ color: theme.color.fgMuted }}>
                 {picked
                   ? "Drag the highlighted region to tune the share clip."
                   : "Drag across the waveform to choose the 30-second clip friends will hear."}
@@ -606,7 +609,7 @@ export default function ShareTrackScreen() {
                 <Text style={{ color: theme.color.fgMuted, fontSize: 12 }}>
                   Share link
                 </Text>
-                <Text selectable style={{ color: theme.color.fg }}>
+                <Text style={{ color: theme.color.fg }}>
                   {shareUrl}
                 </Text>
               </View>
@@ -884,10 +887,7 @@ function StoryBackgroundCropEditor({
       ]}
     >
       <View style={styles.panelHeader}>
-        <Text
-          selectable
-          style={{ color: theme.color.fg, fontSize: 17, fontWeight: "700" }}
-        >
+        <Text style={{ color: theme.color.fg, fontSize: 17, fontWeight: "700" }}>
           Story Background
         </Text>
         <View style={styles.cropActionRow}>
@@ -927,9 +927,11 @@ function StoryBackgroundCropEditor({
           const { width } = event.nativeEvent.layout;
           setLayout({ width, height: cropEditorHeightForWidth(width) });
         }}
+        pointerEvents="box-only"
         {...panResponder.panHandlers}
         style={[
           styles.cropEditor,
+          styles.dragSurface,
           {
             height: editorHeight,
             backgroundColor: theme.color.bg,
@@ -1143,14 +1145,12 @@ function TrackHeader({ track }: { track: TrackDetail }) {
       <View style={{ flex: 1, minWidth: 0 }}>
         <Text
           numberOfLines={2}
-          selectable
           style={{ color: theme.color.fg, fontSize: 22, fontWeight: "700" }}
         >
           {track.title}
         </Text>
         <Text
           numberOfLines={1}
-          selectable
           style={{ color: theme.color.fgMuted, fontSize: 16 }}
         >
           {artist}
@@ -1201,8 +1201,8 @@ function WaveformRegionSelector({
   const panResponder = useMemo(
     () =>
       PanResponder.create({
-        onStartShouldSetPanResponder: () => true,
-        onMoveShouldSetPanResponder: () => true,
+        onStartShouldSetPanResponder: () => durationSec > 0,
+        onMoveShouldSetPanResponder: () => durationSec > 0,
         onPanResponderGrant: (event) => {
           setFromX(event.nativeEvent.locationX);
           void Haptics.selectionAsync();
@@ -1211,7 +1211,7 @@ function WaveformRegionSelector({
           setFromX(event.nativeEvent.locationX);
         },
       }),
-    [setFromX],
+    [durationSec, setFromX],
   );
 
   const onLayout = useCallback((event: LayoutChangeEvent) => {
@@ -1227,9 +1227,11 @@ function WaveformRegionSelector({
   return (
     <View
       onLayout={onLayout}
+      pointerEvents="box-only"
       {...panResponder.panHandlers}
       style={[
         styles.waveform,
+        styles.dragSurface,
         {
           backgroundColor: theme.color.bg,
           borderColor: theme.color.separator,
@@ -1474,6 +1476,9 @@ function isShareDismissal(error: unknown) {
 }
 
 const styles = StyleSheet.create({
+  noDragPage: {
+    userSelect: "none",
+  },
   center: {
     minHeight: 240,
     alignItems: "center",
@@ -1508,6 +1513,9 @@ const styles = StyleSheet.create({
     borderCurve: "continuous",
     borderWidth: StyleSheet.hairlineWidth,
     overflow: "hidden",
+  },
+  dragSurface: {
+    userSelect: "none",
   },
   cropWindow: {
     position: "absolute",

--- a/mobile/components/track-actions-menu.tsx
+++ b/mobile/components/track-actions-menu.tsx
@@ -239,7 +239,7 @@ function TrackActionItems({
           <Divider />
           <Section title="Library">
             <Button
-              label="Go to Album"
+              label="View Album"
               systemImage="square.stack"
               onPress={actions.openAlbum}
             />
@@ -255,7 +255,7 @@ function TrackActionItems({
               systemImage="pencil"
               onPress={actions.openEditMetadata}
             />
-            {actions.hasAlbum ? (
+            {actions.hasEditableAlbum ? (
               <Button
                 label="Edit Album & Cover"
                 systemImage="photo"
@@ -301,12 +301,45 @@ export function useTrackActionModel(track: TrackListItem) {
   }, [toggleFav, track.id]);
 
   const openAlbum = useCallback(() => {
-    if (!track.album_id) return;
-    router.push({
-      pathname: "/(tabs)/(library)/albums/[id]",
-      params: { id: track.album_id },
-    });
-  }, [router, track.album_id]);
+    void (async () => {
+      try {
+        let localAlbumId = track.album_id;
+        let tidalAlbumId =
+          track.source === "tidal" ? track.source_album_id : undefined;
+
+        if (!localAlbumId || (track.source === "tidal" && !tidalAlbumId)) {
+          const detail = await api.getTrack(track.id);
+          localAlbumId = localAlbumId || detail.album_id;
+          if (detail.source === "tidal") {
+            tidalAlbumId = tidalAlbumId || detail.source_album_id;
+          }
+        }
+
+        if (track.source === "tidal" && tidalAlbumId) {
+          router.push({
+            pathname: "/(tabs)/(library)/tidal-albums/[id]" as never,
+            params: { id: tidalAlbumId },
+          });
+          return;
+        }
+
+        if (localAlbumId) {
+          router.push({
+            pathname: "/(tabs)/(library)/albums/[id]",
+            params: { id: localAlbumId },
+          });
+          return;
+        }
+
+        Alert.alert("Album unavailable", "No album was found for this track.");
+      } catch (error) {
+        Alert.alert(
+          "Album unavailable",
+          error instanceof Error ? error.message : "Please try again.",
+        );
+      }
+    })();
+  }, [router, track]);
 
   const openInfo = useCallback(() => {
     router.push({
@@ -422,7 +455,8 @@ export function useTrackActionModel(track: TrackListItem) {
     download,
     downloading,
     favorite,
-    hasAlbum: Boolean(track.album_id),
+    hasAlbum: Boolean(track.album_id || track.album_title || track.source === "tidal"),
+    hasEditableAlbum: Boolean(track.album_id && track.source !== "tidal"),
     isAdmin,
     openAlbum,
     openEditAlbum,

--- a/mobile/lib/query-keys.ts
+++ b/mobile/lib/query-keys.ts
@@ -45,6 +45,8 @@ export const qk = {
   album: (userId: UserId, id: Id) => ["user", userId, "album", id] as const,
   albumTracks: (userId: UserId, id: Id) =>
     ["user", userId, "album-tracks", id] as const,
+  tidalAlbum: (userId: UserId, id: Id) =>
+    ["user", userId, "tidal-album", id] as const,
   artist: (userId: UserId, id: Id) => ["user", userId, "artist", id] as const,
   artistTracks: (userId: UserId, id: Id) =>
     ["user", userId, "artist-tracks", id] as const,


### PR DESCRIPTION
## Summary

Adds a shared �View Album� path for local and TIDAL tracks across web and mobile.

- Adds a backend TIDAL album proxy backed by hifi-api `GET /album/`, returning playable `tidal:<id>` rows.
- Carries remote album ids through search, track details, playlist rows, and shared API types.
- Adds web context-menu album navigation for local rows, materialized TIDAL rows, and live TIDAL search results.
- Adds mobile context-menu album navigation plus a read-only TIDAL album detail screen.

## Impact

Users can jump from a track menu to the album whether the track is local or from TIDAL. Local tracks continue using the existing local album page. TIDAL tracks open a live remote album view with artwork, metadata, play-all, and track rows.

## Validation

- `go test ./internal/tidal ./internal/httpapi/handlers ./internal/playlists` from `backend`
- `npm run build` from `frontend`
- `npx tsc -p tsconfig.json --noEmit` from `mobile`
- `git diff --check`

Note: `npm run lint` from `mobile` still fails on the repo�s existing `import/no-unresolved` handling for `@music-library/core`; no new lint errors remain from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now browse TIDAL album details, including artwork, track listings, and metadata on web and mobile platforms
  * Added "View album" quick action in track context menus
  * Tracks now include source album identifiers for enhanced metadata

* **Tests**
  * Added test coverage for TIDAL album API endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->