### PR TITLE
Remove redundant frontend wrappers and unused hook features

### DIFF
--- a/frontend/src/components/TrackList.tsx
+++ b/frontend/src/components/TrackList.tsx
@@ -109,13 +109,6 @@ export default function TrackList({
     (id: string) => void toggle(id),
     [toggle],
   );
-  const handleEdit = useCallback((id: string) => setEditId(id), []);
-  const handleToggleSelection = useCallback(
-    (track: TrackListItem, index: number, range: boolean) => {
-      toggleSelection(track, index, range);
-    },
-    [toggleSelection],
-  );
   const handleExportSelected = useCallback(() => {
     void exportSelected();
   }, [exportSelected]);
@@ -234,9 +227,9 @@ export default function TrackList({
                   selectionMode={selectionMode}
                   selected={selectedIds.has(t.id)}
                   onPlay={handlePlay}
-                  onToggleSelect={handleToggleSelection}
+                  onToggleSelect={toggleSelection}
                   onToggleFav={handleToggleFav}
-                  onEdit={isAdmin ? handleEdit : undefined}
+                  onEdit={isAdmin ? setEditId : undefined}
                   onContextMenu={handleContextMenu}
                 />
               ))}

--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -51,7 +51,6 @@ export interface BatchExportResult {
   canceled: boolean;
   exported: number;
   failed: number;
-  skipped: number;
   folder?: string;
   errors: string[];
   usedFolderPicker: boolean;
@@ -60,17 +59,11 @@ export interface BatchExportResult {
 export async function exportTracksAsFiles(
   tracks: TrackListItem[],
 ): Promise<BatchExportResult> {
-  // The backend /stream endpoint now serves a full, contiguous file for
-  // every supported source (local files on disk, and TIDAL tracks via HLS
-  // segment assembly), so all tracks are exportable.
-  const exportable = tracks;
-  const skipped = tracks.length - exportable.length;
-  if (exportable.length === 0) {
+  if (tracks.length === 0) {
     return {
       canceled: false,
       exported: 0,
       failed: 0,
-      skipped,
       errors: [],
       usedFolderPicker: false,
     };
@@ -83,7 +76,7 @@ export async function exportTracksAsFiles(
   }> = [];
   let failed = 0;
   const errors: string[] = [];
-  for (const track of exportable) {
+  for (const track of tracks) {
     try {
       let detail: TrackDetail | null = null;
       try {
@@ -114,7 +107,6 @@ export async function exportTracksAsFiles(
         canceled: true,
         exported: 0,
         failed,
-        skipped,
         folder: res.folder,
         errors,
         usedFolderPicker: true,
@@ -125,7 +117,6 @@ export async function exportTracksAsFiles(
         canceled: false,
         exported: 0,
         failed: failed + prepared.length,
-        skipped,
         errors: [...errors, "Desktop export is unavailable."],
         usedFolderPicker: true,
       };
@@ -134,7 +125,6 @@ export async function exportTracksAsFiles(
       canceled: false,
       exported: res.saved ?? 0,
       failed: failed + (res.failed ?? 0),
-      skipped,
       folder: res.folder,
       errors: [...errors, ...(res.errors ?? []), ...(res.error ? [res.error] : [])],
       usedFolderPicker: true,
@@ -149,7 +139,6 @@ export async function exportTracksAsFiles(
     canceled: false,
     exported: prepared.length,
     failed,
-    skipped,
     errors,
     usedFolderPicker: false,
   };

--- a/frontend/src/lib/usePaginatedList.ts
+++ b/frontend/src/lib/usePaginatedList.ts
@@ -10,10 +10,6 @@ interface Options {
   rootMargin?: string;
   /** Poll the server every N ms. Off when undefined or 0. */
   pollIntervalMs?: number;
-  /** When true, keep requesting pages until everything is loaded. Used for
-   *  aggregation views where the user shouldn't need to scroll to get a
-   *  complete picture. */
-  loadAll?: boolean;
 }
 
 export interface PageRequest {
@@ -160,16 +156,5 @@ export function usePaginatedList<T>(
     return () => obs.disconnect();
   }, [loadPage, items, hasMore, rootMargin]);
 
-  // Optional: keep pulling pages until the whole set is loaded, regardless of
-  // scroll. Used by aggregation views.
-  useEffect(() => {
-    if (!opts.loadAll) return;
-    if (items === null || !hasMore) return;
-    if (loadingRef.current) return;
-    void loadPage(items.length, false);
-  }, [opts.loadAll, items, hasMore, loadPage]);
-
-  const reload = useCallback(() => void loadPage(0, true), [loadPage]);
-
-  return { items, total, hasMore, loadingMore, error, sentinelRef, reload };
+  return { items, total, hasMore, loadingMore, error, sentinelRef };
 }

--- a/frontend/src/lib/useTrackSelection.ts
+++ b/frontend/src/lib/useTrackSelection.ts
@@ -27,7 +27,6 @@ interface UseTrackSelectionResult<T> {
   someSelected: boolean;
   exporting: boolean;
   exportNotice: string | null;
-  toggleMode: () => void;
   toggleSelection: (item: T, index: number, range: boolean) => void;
   selectAll: () => void;
   clearSelection: () => void;
@@ -170,11 +169,6 @@ export function useTrackSelection<T>({
     setExportNotice(null);
   }, []);
 
-  const toggleMode = useCallback(() => {
-    setSelectionMode((value) => !value);
-    setExportNotice(null);
-  }, []);
-
   const exportSelected = useCallback(async () => {
     if (exporting || exportableItems.length === 0) return;
     setExporting(true);
@@ -185,10 +179,7 @@ export function useTrackSelection<T>({
         setExportNotice("Export canceled.");
         return;
       }
-      const parts: string[] = [];
-      if (result.failed > 0) parts.push(`${result.failed} failed`);
-      if (result.skipped > 0) parts.push(`${result.skipped} streaming-only skipped`);
-      const suffix = parts.length > 0 ? `, ${parts.join(", ")}` : "";
+      const suffix = result.failed > 0 ? `, ${result.failed} failed` : "";
       setExportNotice(
         result.usedFolderPicker
           ? `Exported ${result.exported} file${result.exported === 1 ? "" : "s"}${suffix}.`
@@ -210,7 +201,6 @@ export function useTrackSelection<T>({
     someSelected,
     exporting,
     exportNotice,
-    toggleMode,
     toggleSelection,
     selectAll,
     clearSelection,

--- a/frontend/src/pages/Library.tsx
+++ b/frontend/src/pages/Library.tsx
@@ -250,13 +250,9 @@ function AlbumsView({
   query: string;
   onOpen: (id: string) => void;
 }) {
-  const fetcher = useCallback(
-    (p: PageRequest) => api.listAlbumsPage(p),
-    [],
-  );
   return (
     <GridView<Album>
-      fetcher={fetcher}
+      fetcher={api.listAlbumsPage}
       query={query}
       pageSize={60}
       unit="album"
@@ -273,13 +269,9 @@ function ArtistsView({
   query: string;
   onOpen: (id: string) => void;
 }) {
-  const fetcher = useCallback(
-    (p: PageRequest) => api.listArtistsPage(p),
-    [],
-  );
   return (
     <GridView<Artist>
-      fetcher={fetcher}
+      fetcher={api.listArtistsPage}
       query={query}
       pageSize={60}
       unit="artist"

--- a/frontend/src/pages/admin/APITrackerPinsSection.tsx
+++ b/frontend/src/pages/admin/APITrackerPinsSection.tsx
@@ -25,11 +25,11 @@ export function APITrackerPinsSection({
   onError: (message: string) => void;
 }) {
   const manager = usePinManager<APITrackerPin, APITrackerDownload>({
-    list: () => api.listAPITrackerPins(),
-    update: (id, patch) => api.updateAPITrackerPin(id, patch),
-    remove: (id) => api.deleteAPITrackerPin(id),
-    scan: (id) => api.scanAPITrackerPin(id),
-    listDownloads: (id, limit) => api.listAPITrackerDownloads(id, limit),
+    list: api.listAPITrackerPins,
+    update: api.updateAPITrackerPin,
+    remove: api.deleteAPITrackerPin,
+    scan: api.scanAPITrackerPin,
+    listDownloads: api.listAPITrackerDownloads,
     kind: "API tracker",
     confirmRemove: (pin) =>
       `Remove API tracker ${pin.label || pin.tracker_name || pin.tracker_id}?\n\nDownloaded files stay on disk and remain in the library.`,

--- a/frontend/src/pages/admin/ArtistGridPinsSection.tsx
+++ b/frontend/src/pages/admin/ArtistGridPinsSection.tsx
@@ -29,11 +29,11 @@ export function ArtistGridPinsSection({
   onError: (message: string) => void;
 }) {
   const manager = usePinManager<ArtistGridPin, ArtistGridDownload>({
-    list: () => api.listArtistGridPins(),
-    update: (id, patch) => api.updateArtistGridPin(id, patch),
-    remove: (id) => api.deleteArtistGridPin(id),
-    scan: (id) => api.scanArtistGridPin(id),
-    listDownloads: (id, limit) => api.listArtistGridDownloads(id, limit),
+    list: api.listArtistGridPins,
+    update: api.updateArtistGridPin,
+    remove: api.deleteArtistGridPin,
+    scan: api.scanArtistGridPin,
+    listDownloads: api.listArtistGridDownloads,
     kind: "tracker",
     confirmRemove: (pin) =>
       `Remove tracker pin ${pin.label || pin.tracker_id}?\n\nDownloaded files stay on disk and remain in the library.`,

--- a/frontend/src/pages/admin/FilenPinsSection.tsx
+++ b/frontend/src/pages/admin/FilenPinsSection.tsx
@@ -24,11 +24,11 @@ export function FilenPinsSection({
   onError: (message: string) => void;
 }) {
   const manager = usePinManager<FilenPin, FilenDownload>({
-    list: () => api.listFilenPins(),
-    update: (id, patch) => api.updateFilenPin(id, patch),
-    remove: (id) => api.deleteFilenPin(id),
-    scan: (id) => api.scanFilenPin(id),
-    listDownloads: (id, limit) => api.listFilenDownloads(id, limit),
+    list: api.listFilenPins,
+    update: api.updateFilenPin,
+    remove: api.deleteFilenPin,
+    scan: api.scanFilenPin,
+    listDownloads: api.listFilenDownloads,
     kind: "Filen share",
     confirmRemove: (pin) =>
       `Remove Filen share ${pin.label || pin.share_url}?\n\nDownloaded files stay on disk and remain in the library.`,

--- a/frontend/src/pages/playlist/trackSort.ts
+++ b/frontend/src/pages/playlist/trackSort.ts
@@ -1,9 +1,4 @@
-import {
-  SORT_DEFAULT_ASC,
-  compareSortableTracks,
-  type SortKey,
-} from "@music-library/core/track-sort";
-import type { PlaylistTrackEntry } from "../../api";
+import type { SortKey } from "@music-library/core/track-sort";
 import type { SelectOption } from "../../components/Select";
 
 // ── Local sorting ────────────────────────────────────────────────────────────
@@ -15,7 +10,11 @@ import type { SelectOption } from "../../components/Select";
 // worded for a desktop dropdown ("Custom order" rather than the phone's
 // "Custom").
 
-export { SORT_DEFAULT_ASC, type SortKey };
+export {
+  SORT_DEFAULT_ASC,
+  compareSortableTracks as compareEntries,
+  type SortKey,
+} from "@music-library/core/track-sort";
 
 export const SORT_OPTIONS: SelectOption<SortKey>[] = [
   { value: "custom", label: "Custom order" },
@@ -23,11 +22,3 @@ export const SORT_OPTIONS: SelectOption<SortKey>[] = [
   { value: "duration", label: "Length" },
   { value: "plays", label: "Plays" },
 ];
-
-export function compareEntries(
-  a: PlaylistTrackEntry,
-  b: PlaylistTrackEntry,
-  key: SortKey,
-): number {
-  return compareSortableTracks(a, b, key);
-}


### PR DESCRIPTION
The frontend retained pass-through callbacks and hook features with no callers. Use the existing stable functions directly and remove unused code while preserving current behavior.

- Remove unused pagination `loadAll` and `reload`, the unused selection `toggleMode`, and always-zero export skip bookkeeping.
- Replace track action, library fetcher, and admin pin API wrappers with direct references; re-export the shared playlist comparator.

Validation: frontend typecheck, lint, all 15 tests, and `git diff --check` pass.
