### PR TITLE
Remove redundant mobile tests and code

### DIFF
--- a/mobile/app/(tabs)/(playlists)/[id].tsx
+++ b/mobile/app/(tabs)/(playlists)/[id].tsx
@@ -79,14 +79,6 @@ type PlaylistTrackRowModel = {
 // copy. Only the option list stays here: it is menu-shaped and worded for a
 // phone context menu ("Custom" rather than the desktop's "Custom order").
 
-function compareModels(
-  a: PlaylistTrackRowModel,
-  b: PlaylistTrackRowModel,
-  key: SortKey,
-): number {
-  return compareSortableTracks(a.entry, b.entry, key);
-}
-
 export default function PlaylistDetailScreen() {
   const theme = useTheme();
   const router = useRouter();
@@ -206,7 +198,9 @@ export default function PlaylistDetailScreen() {
   // What the list actually shows; the play queue follows this order too.
   const displayModels = useMemo<PlaylistTrackRowModel[]>(() => {
     if (sortKey === "custom") return rowModels;
-    const sorted = [...rowModels].sort((a, b) => compareModels(a, b, sortKey));
+    const sorted = [...rowModels].sort((a, b) =>
+      compareSortableTracks(a.entry, b.entry, sortKey),
+    );
     return sortAsc ? sorted : sorted.reverse();
   }, [rowModels, sortKey, sortAsc]);
   const tracks = useMemo<TrackListItem[]>(

--- a/mobile/components/now-playing/bottom-controls.tsx
+++ b/mobile/components/now-playing/bottom-controls.tsx
@@ -66,46 +66,33 @@ export const NowPlayingBottomControls = memo(function NowPlayingBottomControls({
         trackKey={current?.id ?? null}
         time={time}
         isPlaying={isPlaying}
-        onSeek={(seconds) => controls.seek(seconds)}
+        onSeek={controls.seek}
       />
 
       <TransportControls
         isPlaying={isPlaying}
-        onPrev={() => controls.prev()}
-        onToggle={() => controls.toggle()}
-        onNext={() => controls.next()}
+        onPrev={controls.prev}
+        onToggle={controls.toggle}
+        onNext={controls.next}
         style={isTabletLayout ? styles.transportTablet : styles.transport}
       />
 
       <VolumeRow
         value={muted ? 0 : volume}
-        onSetVolume={(value) => controls.setVolume(value)}
+        onSetVolume={controls.setVolume}
         style={isTabletLayout ? styles.volumeRowTablet : styles.volumeRow}
       />
 
-      {isTabletLayout ? (
-        <View style={[styles.toolbar, styles.toolbarTablet]}>
-          <AirPlayButton />
-          <PlaybackDeviceButton glass />
-          <LyricsToggleButton lyricsOpen={lyricsOpen} onPress={toggleLyrics} />
-          <QueueToggleButton
-            queueOpen={queueOpen}
-            shuffle={shuffle}
-            onPress={toggleQueue}
-          />
-        </View>
-      ) : (
-        <View style={styles.toolbar}>
-          <AirPlayButton />
-          <PlaybackDeviceButton glass />
-          <LyricsToggleButton lyricsOpen={lyricsOpen} onPress={toggleLyrics} />
-          <QueueToggleButton
-            queueOpen={queueOpen}
-            shuffle={shuffle}
-            onPress={toggleQueue}
-          />
-        </View>
-      )}
+      <View style={[styles.toolbar, isTabletLayout && styles.toolbarTablet]}>
+        <AirPlayButton />
+        <PlaybackDeviceButton glass />
+        <LyricsToggleButton lyricsOpen={lyricsOpen} onPress={toggleLyrics} />
+        <QueueToggleButton
+          queueOpen={queueOpen}
+          shuffle={shuffle}
+          onPress={toggleQueue}
+        />
+      </View>
     </View>
   );
 });

--- a/mobile/components/siri-media-bridge.tsx
+++ b/mobile/components/siri-media-bridge.tsx
@@ -13,7 +13,6 @@ import {
   usePlayerPlayback,
 } from "../context/player";
 import {
-  loadDefaultSiriMediaQueue,
   loadSiriMediaQueue,
   resolveSiriMediaRequest,
   trackSiriMediaItem,
@@ -201,7 +200,7 @@ export function SiriMediaBridge() {
         }
         const loadedQueue = entity
           ? await loadSiriMediaQueue(entity, controller.signal)
-          : await loadDefaultSiriMediaQueue(controller.signal);
+          : await api.listRecent(100, { signal: controller.signal });
         const playableQueue = loadedQueue.filter((track) =>
           isTrackPlayableOffline(track.id),
         );

--- a/mobile/context/player.tsx
+++ b/mobile/context/player.tsx
@@ -44,7 +44,6 @@ import {
   setLockScreenTrackControlsEnabled,
 } from "../modules/lock-screen-controls";
 
-type Ctx = PlayerState & PlayerControls;
 type PlayerQueueState = Pick<PlayerState, "queue" | "index">;
 type PlayerPlaybackState = Pick<
   PlayerState,
@@ -81,7 +80,6 @@ function createRequiredContext<T>(hookName: string) {
   return [Ctx, useRequiredContext] as const;
 }
 
-const [PlayerCtx, usePlayerCtx] = createRequiredContext<Ctx>("usePlayer");
 const [PlayerControlsCtx, usePlayerControlsCtx] =
   createRequiredContext<PlayerControls>("usePlayerControls");
 const [PlayerPlayCtx, usePlayTrackCtx] =
@@ -101,7 +99,6 @@ const [PlayerVolumeCtx, usePlayerVolumeCtx] =
 const [RemotePlaybackCtx, useRemotePlaybackCtx] =
   createRequiredContext<RemotePlaybackContextValue>("useRemotePlayback");
 
-export const usePlayer = usePlayerCtx;
 export const usePlayerControls = usePlayerControlsCtx;
 export const usePlayTrack = usePlayTrackCtx;
 export const usePlayerTime = usePlayerTimeCtx;
@@ -333,7 +330,6 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     remoteQueue: displayedState.queue,
     canPlayLocally,
   });
-  const routedPlay = routedControls.play;
   // Ticking, not memoized from the heartbeat: snapshots arrive every ~10s,
   // and a memo keyed on them made cast-mode lyrics/scrubber time advance in
   // ten-second leaps. Foreground-gated like `interpolateProgress` above.
@@ -342,10 +338,6 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
     appState === "active",
   );
   const displayedTime = targetDevice ? remoteTime : time;
-  const value = useMemo<Ctx>(
-    () => ({ ...displayedState, ...routedControls }),
-    [displayedState, routedControls],
-  );
   const queueValue = useMemo<PlayerQueueState>(
     () => ({ queue: displayedState.queue, index: displayedState.index }),
     [displayedState.queue, displayedState.index],
@@ -387,25 +379,23 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
 
   return (
     <RemotePlaybackCtx.Provider value={remoteValue}>
-    <PlayerCurrentCtx.Provider value={displayedState.current}>
-      <PlayerIsPlayingCtx.Provider value={displayedState.isPlaying}>
-        <PlayerQueueCtx.Provider value={queueValue}>
-          <PlayerPlaybackCtx.Provider value={playbackValue}>
-            <PlayerVolumeCtx.Provider value={volumeValue}>
-              <PlayerPlayCtx.Provider value={routedControls.play}>
-                <PlayerControlsCtx.Provider value={routedControls}>
-                  <PlayerCtx.Provider value={value}>
+      <PlayerCurrentCtx.Provider value={displayedState.current}>
+        <PlayerIsPlayingCtx.Provider value={displayedState.isPlaying}>
+          <PlayerQueueCtx.Provider value={queueValue}>
+            <PlayerPlaybackCtx.Provider value={playbackValue}>
+              <PlayerVolumeCtx.Provider value={volumeValue}>
+                <PlayerPlayCtx.Provider value={routedControls.play}>
+                  <PlayerControlsCtx.Provider value={routedControls}>
                     <PlayerTimeCtx.Provider value={displayedTime}>
                       {children}
                     </PlayerTimeCtx.Provider>
-                  </PlayerCtx.Provider>
-                </PlayerControlsCtx.Provider>
-              </PlayerPlayCtx.Provider>
-            </PlayerVolumeCtx.Provider>
-          </PlayerPlaybackCtx.Provider>
-        </PlayerQueueCtx.Provider>
-      </PlayerIsPlayingCtx.Provider>
-    </PlayerCurrentCtx.Provider>
+                  </PlayerControlsCtx.Provider>
+                </PlayerPlayCtx.Provider>
+              </PlayerVolumeCtx.Provider>
+            </PlayerPlaybackCtx.Provider>
+          </PlayerQueueCtx.Provider>
+        </PlayerIsPlayingCtx.Provider>
+      </PlayerCurrentCtx.Provider>
     </RemotePlaybackCtx.Provider>
   );
 }

--- a/mobile/lib/siri-media.ts
+++ b/mobile/lib/siri-media.ts
@@ -23,7 +23,6 @@ type SiriCatalogApi = Pick<
   | "listArtistTracks"
   | "listPlaylists"
   | "listPlaylistTracks"
-  | "listRecent"
   | "searchTracks"
 >;
 
@@ -263,14 +262,6 @@ export async function loadSiriMediaQueue(
       ];
     }
   }
-}
-
-/** Queue used for generic requests such as "play music" or "shuffle something". */
-export function loadDefaultSiriMediaQueue(
-  signal?: AbortSignal,
-  client: SiriCatalogApi = api,
-): Promise<TrackListItem[]> {
-  return client.listRecent(100, { signal });
 }
 
 export function trackSiriMediaItem(track: TrackListItem): SiriMediaItem {

--- a/mobile/lib/track-download.ts
+++ b/mobile/lib/track-download.ts
@@ -70,28 +70,14 @@ export function looksLikeMediaBytes(bytes: Uint8Array, contentType?: string) {
   const type = contentType?.split(";")[0]?.toLowerCase().trim();
   if (type?.startsWith("audio/") || type?.startsWith("video/")) return true;
   if (type === "application/octet-stream" || !type) {
-    return hasKnownMediaSignature(bytes);
+    return extensionForMediaBytes(bytes) !== undefined;
   }
   return true;
 }
 
-function hasKnownMediaSignature(bytes: Uint8Array) {
-  const ascii = (offset: number, length: number) =>
-    String.fromCharCode(...bytes.slice(offset, offset + length));
-
-  return (
-    ascii(0, 3) === "ID3" ||
-    ascii(0, 4) === "fLaC" ||
-    ascii(0, 4) === "OggS" ||
-    ascii(0, 4) === "RIFF" ||
-    ascii(4, 4) === "ftyp" ||
-    (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0)
-  );
-}
-
 /** Sniff the audio container from magic bytes (the first 16 are enough).
- *  Mirrors {@link hasKnownMediaSignature}; used when the transport gives no
- *  usable content type (e.g. background downloads finalized after restart). */
+ *  Used for validation and when the transport gives no usable content type
+ *  (e.g. background downloads finalized after restart). */
 export function extensionForMediaBytes(
   bytes: Uint8Array,
 ): "mp3" | "flac" | "ogg" | "wav" | "m4a" | undefined {

--- a/mobile/tests/now-playing-session.test.ts
+++ b/mobile/tests/now-playing-session.test.ts
@@ -7,19 +7,7 @@ import { describe, expect, it } from "vitest";
 import { shouldExposeNowPlayingSession } from "../context/now-playing-session";
 
 describe("shouldExposeNowPlayingSession", () => {
-  it("keeps the session when a loaded track is paused in the background", () => {
-    expect(
-      shouldExposeNowPlayingSession({ hasTrack: true, isCasting: false }),
-    ).toBe(true);
-  });
-
-  it("keeps the session while a loaded track is playing in the background", () => {
-    expect(
-      shouldExposeNowPlayingSession({ hasTrack: true, isCasting: false }),
-    ).toBe(true);
-  });
-
-  it("keeps the session when a loaded track is paused in the foreground", () => {
+  it("keeps the session while a track is loaded locally", () => {
     expect(
       shouldExposeNowPlayingSession({ hasTrack: true, isCasting: false }),
     ).toBe(true);

--- a/mobile/tests/siri-media.test.ts
+++ b/mobile/tests/siri-media.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   decodeSiriMediaIdentifier,
-  loadDefaultSiriMediaQueue,
   loadSiriMediaQueue,
   rankNamedSiriItems,
   resolveSiriMediaRequest,
@@ -185,23 +184,5 @@ describe("Siri catalog matching", () => {
         cover_url: undefined,
       },
     ]);
-  });
-
-  it("uses recent listening for a generic play or shuffle request", async () => {
-    const recent = [
-      {
-        id: "track-1",
-        title: "Recently Played",
-        duration_ms: 120_000,
-      },
-    ];
-    const client = {
-      listRecent: vi.fn().mockResolvedValue(recent),
-    };
-
-    await expect(
-      loadDefaultSiriMediaQueue(undefined, client as never),
-    ).resolves.toBe(recent);
-    expect(client.listRecent).toHaveBeenCalledWith(100, { signal: undefined });
   });
 });


### PR DESCRIPTION
Mobile retained an unused combined player context, forwarding helpers, duplicated toolbar markup and media-signature checks, and tests that repeated inputs or only verified forwarding. Remove that extra code while preserving playback, Siri queue selection, download validation, and phone/tablet styling.

- Remove the unused player context/provider and `routedPlay` variable.
- Pass player controls directly, share the toolbar markup, inline the playlist comparator and generic Siri queue request, and reuse the media-extension detector for validation.
- Collapse duplicate session-policy tests under an accurate name and remove the forwarding-only Siri test (145 → 142 tests).

Validation: all 142 mobile tests pass; mobile lint passes with zero warnings; TypeScript passes with `--noUnusedLocals --noUnusedParameters`; `git diff --check` passes; iOS production export succeeds. The iOS runtime fingerprint matches the latest production build (`6597774ff4167889700457f9314ae529d878c098`).
