### PR TITLE
Fix mobile playback failures during track handoff

### DIFF
--- a/mobile/adapters/expo-audio-adapter.ts
+++ b/mobile/adapters/expo-audio-adapter.ts
@@ -68,6 +68,8 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
   // reversed play() is consumed by the still-ended item and iOS re-pauses,
   // leaving the track stopped at 0:00. play() awaits this to restore ordering.
   const pendingSeekRef = useRef<Promise<void> | null>(null);
+  // Invalidate play() calls waiting on a seek when a newer command takes over.
+  const playbackGenerationRef = useRef(0);
   const prevStatusRef = useRef<{
     isLoaded: boolean;
     playing: boolean;
@@ -108,6 +110,9 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
     };
 
     const subscription = player.addListener("playbackStatusUpdate", (status) => {
+      // The prepared replacement has not started yet. An already-queued end
+      // notification belongs to the outgoing item, not this replacement.
+      if (pendingPreparedPlaybackRef.current && status.didJustFinish) return;
       const prev = prevStatusRef.current;
       const isLoaded = status.isLoaded;
       const didJustFinish = status.didJustFinish;
@@ -124,7 +129,21 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
         (status.timeControlStatus === "waitingToPlayAtSpecifiedRate" &&
           status.reasonForWaitingToPlay !== "noItemToPlay");
 
-      startPreparedPlaybackIfReady(status);
+      // Commit before dispatch: an ended listener can synchronously replace
+      // the source and reset this diff for the incoming track.
+      prevStatusRef.current = { isLoaded, playing, didJustFinish, duration };
+
+      try {
+        startPreparedPlaybackIfReady(status);
+      } catch (error) {
+        // Unlike adapter.play(), this native event callback has no promise
+        // for the core to catch. Reflect the failure as paused so it can be
+        // retried, and stop processing the snapshot that preceded the error.
+        prevStatusRef.current.playing = false;
+        console.warn("Could not start prepared audio playback", error);
+        dispatch("pause");
+        return;
+      }
 
       if (!prev.isLoaded && isLoaded) {
         dispatch("loadedmetadata");
@@ -140,8 +159,6 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
       if (prev.playing && !playing && !didJustFinish) dispatch("pause");
       if (isLoaded) dispatch("timeupdate");
       if (!prev.didJustFinish && didJustFinish) dispatch("ended");
-
-      prevStatusRef.current = { isLoaded, playing, didJustFinish, duration };
     });
 
     return () => {
@@ -152,6 +169,7 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
   const adapter = useMemo<ExpoAudioAdapter>(
     () => ({
       load(url) {
+        playbackGenerationRef.current += 1;
         pendingPreparedPlaybackRef.current = null;
         // Seeks against the outgoing item must not delay the new track.
         pendingSeekRef.current = null;
@@ -196,6 +214,7 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
         if (!prepared || prepared.url !== url || !prepared.ready) return false;
         preparedRef.current = null;
         prepareGenerationRef.current += 1;
+        playbackGenerationRef.current += 1;
         try {
           // A preloaded AVPlayerItem can still report loading briefly while it
           // is moved onto the active player. At a natural track end the old
@@ -233,6 +252,7 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
         if (prepared) void clearPreloadedSource(prepared.url).catch(() => {});
       },
       async play() {
+        const generation = playbackGenerationRef.current;
         const pending = pendingPreparedPlaybackRef.current;
         if (pending) {
           pending.shouldPlay = true;
@@ -242,13 +262,19 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
         const pendingSeek = pendingSeekRef.current;
         if (pendingSeek) {
           await pendingSeek;
-          // A load()/activatePrepared() while the seek settled owns playback
-          // ordering itself; don't also start the (replaced) item.
-          if (pendingPreparedPlaybackRef.current) return;
+          // A newer source, pause or disposal owns playback now; the old
+          // seek completion must not restart it.
+          if (
+            generation !== playbackGenerationRef.current ||
+            pendingPreparedPlaybackRef.current
+          ) {
+            return;
+          }
         }
         player.play();
       },
       pause() {
+        playbackGenerationRef.current += 1;
         const pending = pendingPreparedPlaybackRef.current;
         if (pending) pending.shouldPlay = false;
         player.pause();
@@ -307,6 +333,8 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
         };
       },
       dispose() {
+        playbackGenerationRef.current += 1;
+        pendingSeekRef.current = null;
         pendingPreparedPlaybackRef.current = null;
         const prepared = preparedRef.current;
         preparedRef.current = null;

--- a/mobile/adapters/expo-audio-adapter.ts
+++ b/mobile/adapters/expo-audio-adapter.ts
@@ -62,6 +62,7 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
   const pendingPreparedPlaybackRef = useRef<{ shouldPlay: boolean } | null>(
     null,
   );
+  const awaitingSourceStatusRef = useRef(false);
   // In-flight seekTo(). expo-audio's seekTo is an async native function while
   // play() is sync, so an unawaited seek(0)+play() pair reaches the native
   // player in reverse order. At a natural track end (repeat-one restart) the
@@ -110,9 +111,14 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
     };
 
     const subscription = player.addListener("playbackStatusUpdate", (status) => {
-      // The prepared replacement has not started yet. An already-queued end
-      // notification belongs to the outgoing item, not this replacement.
-      if (pendingPreparedPlaybackRef.current && status.didJustFinish) return;
+      // A synchronous prepared start can clear the pending-play flag before
+      // queued events arrive. Suppress outgoing ends until an ordinary source
+      // status arrives, and while a prepared source still awaits playback.
+      if (
+        status.didJustFinish &&
+        (awaitingSourceStatusRef.current || pendingPreparedPlaybackRef.current)
+      ) return;
+      awaitingSourceStatusRef.current = false;
       const prev = prevStatusRef.current;
       const isLoaded = status.isLoaded;
       const didJustFinish = status.didJustFinish;
@@ -181,6 +187,7 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
           prepareGenerationRef.current += 1;
           void clearPreloadedSource(prepared.url).catch(() => {});
         }
+        awaitingSourceStatusRef.current = true;
         player.replace({ uri: url });
         // Reset the status diff so the new track's first loadedmetadata fires.
         prevStatusRef.current.isLoaded = false;
@@ -228,6 +235,7 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
             shouldPlay: true,
           };
           pendingSeekRef.current = null;
+          awaitingSourceStatusRef.current = true;
           player.replace({ uri: url });
           prevStatusRef.current.isLoaded = false;
           prevStatusRef.current.duration = 0;

--- a/mobile/adapters/expo-audio-adapter.ts
+++ b/mobile/adapters/expo-audio-adapter.ts
@@ -133,6 +133,14 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
       // the source and reset this diff for the incoming track.
       prevStatusRef.current = { isLoaded, playing, didJustFinish, duration };
 
+      // Loading succeeded even if starting playback fails. Publish metadata
+      // before that attempt so a paused song still has a usable timeline.
+      if (!prev.isLoaded && isLoaded) {
+        dispatch("loadedmetadata");
+      } else if (duration > 0 && prev.duration === 0) {
+        dispatch("loadedmetadata");
+      }
+
       try {
         startPreparedPlaybackIfReady(status);
       } catch (error) {
@@ -143,12 +151,6 @@ export function useExpoAudioAdapter(): ExpoAudioAdapter {
         console.warn("Could not start prepared audio playback", error);
         dispatch("pause");
         return;
-      }
-
-      if (!prev.isLoaded && isLoaded) {
-        dispatch("loadedmetadata");
-      } else if (duration > 0 && prev.duration === 0) {
-        dispatch("loadedmetadata");
       }
 
       if (!prev.playing && playing) dispatch("play");

--- a/mobile/tests/expo-audio-adapter.test.ts
+++ b/mobile/tests/expo-audio-adapter.test.ts
@@ -342,6 +342,24 @@ describe("useExpoAudioAdapter prepared track handoff", () => {
     expect(ended).toHaveBeenCalledOnce();
   });
 
+  it("publishes the loaded duration even when starting the prepared song fails", async () => {
+    const adapter = await prepare();
+    const durations: number[] = [];
+    adapter.on("loadedmetadata", () => durations.push(adapter.duration()));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(h.fakePlayer, "play").mockImplementationOnce(() => {
+      throw new Error("audio session activation failed");
+    });
+    h.fakePlayer.duration = ready.duration;
+
+    h.emitStatus(ready);
+    expect(durations).toEqual([100]);
+
+    await adapter.play();
+    h.emitStatus({ ...ready, playing: true });
+    expect(durations).toEqual([100]);
+  });
+
   it("honors pause while the prepared song is loading", async () => {
     const adapter = await prepare();
     adapter.pause();

--- a/mobile/tests/expo-audio-adapter.test.ts
+++ b/mobile/tests/expo-audio-adapter.test.ts
@@ -292,16 +292,28 @@ describe("useExpoAudioAdapter status → event translation", () => {
     h.emitStatus(playingStatus());
     expect(metadata).toHaveBeenCalledOnce();
   });
+
+  it("ignores an outgoing end immediately after loading another source", () => {
+    const { adapter, events } = setup();
+    h.emitStatus(playingStatus());
+    adapter.load("https://example.test/next.mp3");
+    h.emitStatus(status({ didJustFinish: true }));
+    expect(events).toEqual(["play"]);
+
+    h.emitStatus(playingStatus());
+    h.emitStatus(status({ didJustFinish: true }));
+    expect(events).toEqual(["play", "play", "ended"]);
+  });
 });
 
 describe("useExpoAudioAdapter prepared track handoff", () => {
   const ready = { isLoaded: true, playing: false, didJustFinish: false, duration: 100 };
 
-  async function prepare() {
+  async function prepare(isLoaded = false) {
     const adapter = createTestAdapter();
     adapter.prepareNext!("https://example.test/next.mp3");
     await flushMicrotasks();
-    h.fakePlayer.currentStatus = { ...ready, isLoaded: false };
+    h.fakePlayer.currentStatus = { ...ready, isLoaded };
     expect(adapter.activatePrepared!("https://example.test/next.mp3")).toBe(true);
     return adapter;
   }
@@ -326,14 +338,14 @@ describe("useExpoAudioAdapter prepared track handoff", () => {
     expect(h.calls.at(-1)).toBe("play");
   });
 
-  it("ignores outgoing end events while the prepared replacement awaits playback", async () => {
-    const adapter = await prepare();
+  it.each([false, true])("ignores outgoing ends after prepared activation (already loaded: %s)", async (isLoaded) => {
+    const adapter = await prepare(isLoaded);
     const ended = vi.fn();
     adapter.on("ended", ended);
 
     h.emitStatus({ ...ready, didJustFinish: true });
     expect(ended).not.toHaveBeenCalled();
-    expect(h.calls).not.toContain("play");
+    expect(h.calls.filter((call) => call === "play")).toHaveLength(isLoaded ? 1 : 0);
 
     h.emitStatus(ready);
     expect(h.calls.at(-1)).toBe("play");

--- a/mobile/tests/expo-audio-adapter.test.ts
+++ b/mobile/tests/expo-audio-adapter.test.ts
@@ -10,6 +10,8 @@
  * React is shimmed and the hook is called as a plain function.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+// React is shimmed below; this factory performs a single render of the hook.
+import { useExpoAudioAdapter as createTestAdapter } from "../adapters/expo-audio-adapter";
 
 const h = vi.hoisted(() => {
   const calls: string[] = [];
@@ -85,18 +87,22 @@ vi.mock("expo-audio/build/AudioModule", () => ({
   },
 }));
 
-import { useExpoAudioAdapter } from "../adapters/expo-audio-adapter";
-
 /** Yield so already-resolved promise chains inside the adapter can run. */
 const flushMicrotasks = () => new Promise<void>((r) => setTimeout(r, 0));
 
-describe("useExpoAudioAdapter seek/play ordering", () => {
-  beforeEach(() => {
-    h.calls.length = 0;
-  });
+beforeEach(() => {
+  vi.restoreAllMocks();
+  h.calls.length = 0;
+  h.fakePlayer.currentTime = 0;
+  h.fakePlayer.duration = 0;
+  h.fakePlayer.currentStatus = {
+    isLoaded: true, playing: false, didJustFinish: false, duration: 0,
+  };
+});
 
+describe("useExpoAudioAdapter seek/play ordering", () => {
   it("holds play() until a pending seek settles (repeat-one restart)", async () => {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
 
     adapter.seek(0);
     const playPromise = adapter.play();
@@ -109,14 +115,14 @@ describe("useExpoAudioAdapter seek/play ordering", () => {
   });
 
   it("plays immediately when no seek is pending", async () => {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
 
     await adapter.play();
     expect(h.calls).toEqual(["play"]);
   });
 
   it("does not let a stale seek on the outgoing track delay the next one", async () => {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
 
     adapter.seek(0);
     adapter.load("https://example.test/next.mp3");
@@ -125,7 +131,7 @@ describe("useExpoAudioAdapter seek/play ordering", () => {
   });
 
   it("clears the pending seek once it settles", async () => {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
 
     adapter.seek(0);
     h.finishSeek();
@@ -134,8 +140,22 @@ describe("useExpoAudioAdapter seek/play ordering", () => {
     expect(h.calls).toEqual(["seekTo", "play"]);
   });
 
+  it.each(["load", "pause", "dispose"] as const)(
+    "cancels a waiting restart when %s takes over",
+    async (command) => {
+      const adapter = createTestAdapter();
+      adapter.seek(0);
+      const pendingPlay = adapter.play();
+      if (command === "load") adapter.load("https://example.test/next.mp3");
+      else adapter[command]();
+      h.finishSeek();
+      await pendingPlay;
+      expect(h.calls).not.toContain("play");
+    },
+  );
+
   it("reports seeked only after the native playhead has moved", async () => {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
     h.fakePlayer.currentTime = 40;
     const positions: number[] = [];
     adapter.on("seeked", () => positions.push(adapter.currentTime()));
@@ -147,7 +167,7 @@ describe("useExpoAudioAdapter seek/play ordering", () => {
   });
 
   it("does not publish a seek completion for a replaced track", async () => {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
     const seeked = vi.fn();
     adapter.on("seeked", seeked);
     adapter.seek(90);
@@ -158,7 +178,7 @@ describe("useExpoAudioAdapter seek/play ordering", () => {
   });
 
   it("ignores superseded and failed seeks", async () => {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
     const seeked = vi.fn();
     adapter.on("seeked", seeked);
     adapter.seek(10);
@@ -195,7 +215,7 @@ describe("useExpoAudioAdapter status → event translation", () => {
     status({ playing: true, timeControlStatus: "playing" });
 
   function setup() {
-    const adapter = useExpoAudioAdapter();
+    const adapter = createTestAdapter();
     const events: string[] = [];
     adapter.on("play", () => events.push("play"));
     adapter.on("pause", () => events.push("pause"));
@@ -258,5 +278,90 @@ describe("useExpoAudioAdapter status → event translation", () => {
     h.emitStatus(status({ playing: false, isLoaded: false, duration: 0 }));
     h.emitStatus(playingStatus());
     expect(events).toEqual(["play", "play"]);
+  });
+
+  it("preserves the incoming metadata reset when ended loads the next track", () => {
+    const { adapter } = setup();
+    const metadata = vi.fn();
+    h.emitStatus(playingStatus());
+    adapter.on("loadedmetadata", metadata);
+    adapter.on("ended", () => adapter.load("https://example.test/next.mp3"));
+
+    h.emitStatus(status({ didJustFinish: true }));
+    // Both songs have the same duration and the replacement is already loaded.
+    h.emitStatus(playingStatus());
+    expect(metadata).toHaveBeenCalledOnce();
+  });
+});
+
+describe("useExpoAudioAdapter prepared track handoff", () => {
+  const ready = { isLoaded: true, playing: false, didJustFinish: false, duration: 100 };
+
+  async function prepare() {
+    const adapter = createTestAdapter();
+    adapter.prepareNext!("https://example.test/next.mp3");
+    await flushMicrotasks();
+    h.fakePlayer.currentStatus = { ...ready, isLoaded: false };
+    expect(adapter.activatePrepared!("https://example.test/next.mp3")).toBe(true);
+    return adapter;
+  }
+
+  it("pauses on deferred native play failure without throwing, then allows retry", async () => {
+    const adapter = await prepare();
+    const pause = vi.fn();
+    const play = vi.fn();
+    adapter.on("pause", pause);
+    adapter.on("play", play);
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = new Error("audio session activation failed");
+    vi.spyOn(h.fakePlayer, "play").mockImplementationOnce(() => { throw error; });
+
+    // Even a snapshot marked playing must not undo the failed-start pause.
+    expect(() => h.emitStatus({ ...ready, playing: true })).not.toThrow();
+    expect(pause).toHaveBeenCalledOnce();
+    expect(play).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledWith("Could not start prepared audio playback", error);
+
+    await adapter.play();
+    expect(h.calls.at(-1)).toBe("play");
+  });
+
+  it("ignores outgoing end events while the prepared replacement awaits playback", async () => {
+    const adapter = await prepare();
+    const ended = vi.fn();
+    adapter.on("ended", ended);
+
+    h.emitStatus({ ...ready, didJustFinish: true });
+    expect(ended).not.toHaveBeenCalled();
+    expect(h.calls).not.toContain("play");
+
+    h.emitStatus(ready);
+    expect(h.calls.at(-1)).toBe("play");
+    h.emitStatus({ ...ready, playing: true });
+    h.emitStatus({ ...ready, didJustFinish: true });
+    expect(ended).toHaveBeenCalledOnce();
+  });
+
+  it("honors pause while the prepared song is loading", async () => {
+    const adapter = await prepare();
+    adapter.pause();
+    h.emitStatus(ready);
+    expect(h.calls).not.toContain("play");
+    await adapter.play();
+    expect(h.calls.at(-1)).toBe("play");
+  });
+
+  it("does not start another song when the outgoing seek completes", async () => {
+    const adapter = createTestAdapter();
+    adapter.seek(0);
+    const pendingPlay = adapter.play();
+    adapter.prepareNext!("https://example.test/next.mp3");
+    await flushMicrotasks();
+    h.fakePlayer.currentStatus = ready;
+    expect(adapter.activatePrepared!("https://example.test/next.mp3")).toBe(true);
+    adapter.pause();
+    h.finishSeek();
+    await pendingPlay;
+    expect(h.calls).toEqual(["seekTo", "replace", "play", "pause"]);
   });
 });


### PR DESCRIPTION
A native play failure while a prepared song becomes ready escaped the playback event callback, allowing an unhandled JavaScript exception. Publish the loaded duration before attempting playback, catch start failures, and report playback as paused so the user can retry with a working progress display.

Also ignore queued outgoing end events across ordinary and prepared source replacements, preserve the incoming metadata reset when an end handler loads the next track, and cancel seek-delayed restarts after a source change, pause, or disposal.

Validation: 159 mobile tests pass, including 23 adapter tests with eleven new regression cases; mobile TypeScript checking and lint for both changed files pass. The reported TestFlight crash lacks its JavaScript message, so this addresses reproduced failure paths without claiming its exact cause is established. No native changes.
